### PR TITLE
Administer LexCerta API keys securely

### DIFF
--- a/migrations/0002_admin_key_lifecycle.sql
+++ b/migrations/0002_admin_key_lifecycle.sql
@@ -1,0 +1,22 @@
+ALTER TABLE customers ADD COLUMN retention_expires_at TEXT;
+ALTER TABLE api_key_records ADD COLUMN retention_expires_at TEXT;
+
+CREATE TABLE IF NOT EXISTS admin_audit_events (
+	id TEXT PRIMARY KEY NOT NULL,
+	action TEXT NOT NULL CHECK (action IN ('key_issued', 'key_rotated', 'key_revoked', 'key_limits_changed')),
+	actor_subject TEXT NOT NULL CHECK (length(actor_subject) BETWEEN 1 AND 256),
+	customer_id TEXT NOT NULL REFERENCES customers(id),
+	public_id TEXT REFERENCES api_key_records(public_id) ON DELETE SET NULL,
+	environment TEXT NOT NULL CHECK (environment IN ('production', 'test')),
+	occurred_at TEXT NOT NULL,
+	retention_expires_at TEXT NOT NULL,
+	metadata_json TEXT NOT NULL DEFAULT '{}' CHECK (length(metadata_json) <= 2048)
+);
+
+CREATE INDEX IF NOT EXISTS admin_audit_events_retention_idx
+	ON admin_audit_events(retention_expires_at);
+CREATE INDEX IF NOT EXISTS admin_audit_events_customer_idx
+	ON admin_audit_events(customer_id, occurred_at);
+
+CREATE INDEX IF NOT EXISTS api_key_records_retention_idx
+	ON api_key_records(retention_expires_at);

--- a/package.json
+++ b/package.json
@@ -6,14 +6,15 @@
 	"scripts": {
 		"dev": "wrangler dev --env local",
 		"deploy": "wrangler deploy --env=\"\"",
-		"test": "vitest run",
+		"test": "vitest run && npm run test:admin",
+		"test:admin": "vitest run --config vitest.admin.config.ts",
 		"test:watch": "vitest",
 		"types": "wrangler types worker-configuration.d.ts",
 		"types:check": "wrangler types worker-configuration.d.ts --check",
 		"typecheck": "npm run types:check && tsc --noEmit && tsc --project test/tsconfig.json --noEmit",
-		"lint": "biome lint src/worker.ts src/mcp.ts src/auth src/verification test vitest.config.ts",
-		"format": "biome format --write package.json tsconfig.json test/tsconfig.json vitest.config.ts wrangler.jsonc src/worker.ts src/mcp.ts src/auth src/verification test",
-		"format:check": "biome format package.json tsconfig.json test/tsconfig.json vitest.config.ts wrangler.jsonc src/worker.ts src/mcp.ts src/auth src/verification test",
+		"lint": "biome lint src/admin src/worker.ts src/mcp.ts src/auth src/verification test vitest.config.ts vitest.admin.config.ts",
+		"format": "biome format --write package.json tsconfig.json test/tsconfig.json vitest.config.ts vitest.admin.config.ts wrangler.jsonc wrangler.admin.jsonc src/admin src/worker.ts src/mcp.ts src/auth src/verification test",
+		"format:check": "biome format package.json tsconfig.json test/tsconfig.json vitest.config.ts vitest.admin.config.ts wrangler.jsonc wrangler.admin.jsonc src/admin src/worker.ts src/mcp.ts src/auth src/verification test",
 		"check": "npm run format:check && npm run lint && npm run typecheck && npm run test"
 	},
 	"dependencies": {

--- a/src/admin/access.ts
+++ b/src/admin/access.ts
@@ -1,0 +1,144 @@
+import { z } from "zod";
+
+const ACCESS_ASSERTION_HEADER = "cf-access-jwt-assertion";
+const ACCESS_JWT_HEADER_SCHEMA = z.object({ alg: z.literal("RS256"), kid: z.string().min(1) });
+const ACCESS_JWT_PAYLOAD_SCHEMA = z.object({
+	aud: z.union([z.string().min(1), z.array(z.string().min(1)).min(1)]),
+	exp: z.number().finite(),
+	iss: z.string().url(),
+	nbf: z.number().finite().optional(),
+	sub: z.string(),
+});
+const ACCESS_JWK_SCHEMA = z
+	.object({
+		alg: z.literal("RS256"),
+		e: z.string().min(1),
+		kid: z.string().min(1),
+		kty: z.literal("RSA"),
+		n: z.string().min(1),
+	})
+	.passthrough();
+const ACCESS_JWKS_SCHEMA = z.object({ keys: z.array(ACCESS_JWK_SCHEMA) });
+
+export type AccessEnvironment = {
+	readonly ACCESS_AUDIENCE?: string;
+	readonly ACCESS_ISSUER?: string;
+	readonly ACCESS_JWKS_URL?: string;
+	readonly ACCESS_OPERATOR_SUBJECT?: string;
+};
+
+export type AccessIdentity = { readonly subject: string };
+
+type AccessConfiguration = {
+	readonly audience: string;
+	readonly issuer: string;
+	readonly jwksUrl: string;
+	readonly operatorSubject: string;
+};
+
+export async function verifyAccessIdentity(
+	request: Request,
+	env: AccessEnvironment,
+): Promise<AccessIdentity | null> {
+	const assertion = request.headers.get(ACCESS_ASSERTION_HEADER);
+	const configuration = accessConfiguration(env);
+	if (assertion === null || configuration === null) return null;
+	const pieces = assertion.split(".");
+	const encodedHeader = pieces[0];
+	const encodedPayload = pieces[1];
+	const encodedSignature = pieces[2];
+	if (
+		pieces.length !== 3 ||
+		encodedHeader === undefined ||
+		encodedPayload === undefined ||
+		encodedSignature === undefined
+	)
+		return null;
+
+	const header = parseJwtPart(encodedHeader, ACCESS_JWT_HEADER_SCHEMA);
+	const payload = parseJwtPart(encodedPayload, ACCESS_JWT_PAYLOAD_SCHEMA);
+	const signature = decodeBase64Url(encodedSignature);
+	if (header === null || payload === null || signature === null) return null;
+	if (
+		payload.iss !== configuration.issuer ||
+		!audienceIncludes(payload.aud, configuration.audience)
+	)
+		return null;
+	const now = Math.floor(Date.now() / 1_000);
+	if (payload.exp <= now || (payload.nbf !== undefined && payload.nbf > now)) return null;
+	if (payload.sub.length === 0 || payload.sub !== configuration.operatorSubject) return null;
+
+	try {
+		const jwksResponse = await fetch(configuration.jwksUrl, { signal: AbortSignal.timeout(2_000) });
+		if (!jwksResponse.ok) return null;
+		const jwks = ACCESS_JWKS_SCHEMA.safeParse(await jwksResponse.json());
+		const jwk = jwks.success
+			? jwks.data.keys.find((candidate) => candidate.kid === header.kid)
+			: undefined;
+		if (jwk === undefined) return null;
+		const verificationKey = await crypto.subtle.importKey(
+			"jwk",
+			jwk,
+			{ name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+			false,
+			["verify"],
+		);
+		return (await crypto.subtle.verify(
+			"RSASSA-PKCS1-v1_5",
+			verificationKey,
+			signature,
+			new TextEncoder().encode(`${encodedHeader}.${encodedPayload}`),
+		))
+			? { subject: payload.sub }
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function parseJwtPart<T>(value: string, schema: z.ZodType<T>): T | null {
+	const decoded = decodeBase64Url(value);
+	if (decoded === null) return null;
+	try {
+		return schema.safeParse(JSON.parse(new TextDecoder().decode(decoded))).data ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function decodeBase64Url(value: string): Uint8Array | null {
+	if (!/^[A-Za-z0-9_-]+$/u.test(value)) return null;
+	try {
+		const padded = value
+			.replaceAll("-", "+")
+			.replaceAll("_", "/")
+			.padEnd(Math.ceil(value.length / 4) * 4, "=");
+		return Uint8Array.from(atob(padded), (character) => character.codePointAt(0) ?? 0);
+	} catch {
+		return null;
+	}
+}
+
+function audienceIncludes(audience: string | readonly string[], expected: string): boolean {
+	return typeof audience === "string" ? audience === expected : audience.includes(expected);
+}
+
+function accessConfiguration(env: AccessEnvironment): AccessConfiguration | null {
+	if (
+		!isNonEmptyString(env.ACCESS_AUDIENCE) ||
+		!isNonEmptyString(env.ACCESS_ISSUER) ||
+		!isNonEmptyString(env.ACCESS_JWKS_URL) ||
+		!isNonEmptyString(env.ACCESS_OPERATOR_SUBJECT)
+	)
+		return null;
+	return {
+		audience: env.ACCESS_AUDIENCE,
+		issuer: env.ACCESS_ISSUER,
+		jwksUrl: env.ACCESS_JWKS_URL,
+		operatorSubject: env.ACCESS_OPERATOR_SUBJECT,
+	};
+}
+
+function isNonEmptyString(value: unknown): value is string {
+	return typeof value === "string" && value.length > 0;
+}

--- a/src/admin/credentials.ts
+++ b/src/admin/credentials.ts
@@ -1,0 +1,21 @@
+export function apiKeyPepper(value: unknown): string | null {
+	return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+export async function hmacSha256Hex(pepper: string, token: string): Promise<string> {
+	const cryptoKey = await crypto.subtle.importKey(
+		"raw",
+		new TextEncoder().encode(pepper),
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const bytes = new Uint8Array(
+		await crypto.subtle.sign("HMAC", cryptoKey, new TextEncoder().encode(token)),
+	);
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+export function secretBytes(): Uint8Array {
+	return crypto.getRandomValues(new Uint8Array(32));
+}

--- a/src/admin/key-lifecycle.test.ts
+++ b/src/admin/key-lifecycle.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { createApiKeyPublicId } from "../auth/api-key.js";
+import {
+	DEFAULT_API_KEY_LIMITS,
+	changeApiKeyLimits,
+	issueApiKey,
+	revokeApiKey,
+	rotateApiKey,
+	type ApiKeyLifecycleRecord,
+} from "./key-lifecycle.js";
+
+const ISSUED_AT = new Date("2026-01-01T00:00:00.000Z");
+const CUSTOMER_ID = "customer_01";
+const OPERATOR_SUBJECT = "access-subject-01";
+const PUBLIC_ID = createApiKeyPublicId("key-01");
+
+function secretBytes(): Uint8Array {
+	return Uint8Array.from({ length: 32 }, (_, index) => index);
+}
+
+describe("issueApiKey", () => {
+	it("constructs the supplied 32-byte secret as a one-time production token with the default 90-day expiry", () => {
+		const result = issueApiKey({
+			customerId: CUSTOMER_ID,
+			environment: "production",
+			issuedAt: ISSUED_AT,
+			operatorSubject: OPERATOR_SUBJECT,
+			publicId: PUBLIC_ID,
+			secret: secretBytes(),
+		});
+
+		expect(result).toMatchObject({
+			kind: "issued",
+			key: {
+				customerId: CUSTOMER_ID,
+				environment: "production",
+				expiresAt: "2026-04-01T00:00:00.000Z",
+				issuedAt: "2026-01-01T00:00:00.000Z",
+				limits: DEFAULT_API_KEY_LIMITS,
+				publicId: PUBLIC_ID,
+				status: "active",
+			},
+			plaintextCredential: {
+				kind: "one_time_plaintext_credential",
+				token: "lc_live_key-01_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+			},
+		});
+	});
+
+	it("rejects a secret that is not exactly 32 bytes", () => {
+		const result = issueApiKey({
+			customerId: CUSTOMER_ID,
+			environment: "test",
+			issuedAt: ISSUED_AT,
+			operatorSubject: OPERATOR_SUBJECT,
+			publicId: PUBLIC_ID,
+			secret: new Uint8Array(31),
+		});
+
+		expect(result).toEqual({ kind: "invalid_secret_length", receivedByteLength: 31 });
+	});
+
+	it("uses the non-production credential prefix", () => {
+		const result = issueApiKey({
+			customerId: CUSTOMER_ID,
+			environment: "test",
+			issuedAt: ISSUED_AT,
+			operatorSubject: OPERATOR_SUBJECT,
+			publicId: PUBLIC_ID,
+			secret: secretBytes(),
+		});
+
+		expect(result).toMatchObject({
+			kind: "issued",
+			plaintextCredential: {
+				kind: "one_time_plaintext_credential",
+				token: "lc_test_key-01_AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8",
+			},
+		});
+	});
+});
+
+describe("rotateApiKey", () => {
+	it("limits an active prior key to a seven-day overlap while issuing a fresh 90-day token", () => {
+		const priorKey = activeKey({ expiresAt: "2026-04-01T00:00:00.000Z" });
+
+		const result = rotateApiKey({
+			issuedAt: ISSUED_AT,
+			operatorSubject: OPERATOR_SUBJECT,
+			priorKey,
+			publicId: createApiKeyPublicId("key-02"),
+			secret: secretBytes(),
+		});
+
+		expect(result).toMatchObject({
+			kind: "rotated",
+			newKey: {
+				expiresAt: "2026-04-01T00:00:00.000Z",
+				rotationParentId: PUBLIC_ID,
+			},
+			priorKey: {
+				expiresAt: "2026-01-08T00:00:00.000Z",
+				rotationOverlapUntil: "2026-01-08T00:00:00.000Z",
+			},
+		});
+	});
+
+	it("never extends a prior key that expires sooner than the permitted overlap", () => {
+		const priorKey = activeKey({ expiresAt: "2026-01-03T00:00:00.000Z" });
+
+		const result = rotateApiKey({
+			issuedAt: ISSUED_AT,
+			operatorSubject: OPERATOR_SUBJECT,
+			priorKey,
+			publicId: createApiKeyPublicId("key-02"),
+			secret: secretBytes(),
+		});
+
+		expect(result).toMatchObject({
+			kind: "rotated",
+			priorKey: {
+				expiresAt: "2026-01-03T00:00:00.000Z",
+				rotationOverlapUntil: "2026-01-03T00:00:00.000Z",
+			},
+		});
+	});
+});
+
+describe("revokeApiKey", () => {
+	it("returns an immediate revocation decision and a credential-free audit event", () => {
+		const active = activeKey({ expiresAt: "2026-04-01T00:00:00.000Z" });
+		const result = revokeApiKey({
+			key: active,
+			operatorSubject: OPERATOR_SUBJECT,
+			revokedAt: ISSUED_AT,
+		});
+
+		expect(result).toMatchObject({
+			kind: "revoked",
+			key: { revokedAt: "2026-01-01T00:00:00.000Z", status: "revoked" },
+			auditEvent: {
+				action: "key_revoked",
+				actorSubject: OPERATOR_SUBJECT,
+				keyPublicId: PUBLIC_ID,
+				occurredAt: "2026-01-01T00:00:00.000Z",
+			},
+		});
+		expect(JSON.stringify(result)).not.toContain("lc_");
+	});
+});
+
+describe("changeApiKeyLimits", () => {
+	it("accepts positive safe integer limits and emits a sanitized lifecycle audit event", () => {
+		const result = changeApiKeyLimits({
+			key: activeKey({ expiresAt: "2026-04-01T00:00:00.000Z" }),
+			limits: { day: 10_000, minute: 120 },
+			occurredAt: ISSUED_AT,
+			operatorSubject: OPERATOR_SUBJECT,
+		});
+
+		expect(result).toMatchObject({
+			kind: "limits_changed",
+			key: { limits: { day: 10_000, minute: 120 } },
+			auditEvent: { action: "key_limits_changed", keyPublicId: PUBLIC_ID },
+		});
+	});
+
+	it.each([
+		{ day: 1_000, minute: 0 },
+		{ day: 0, minute: 60 },
+		{ day: 1.5, minute: 60 },
+		{ day: Number.MAX_SAFE_INTEGER + 1, minute: 60 },
+	])("rejects invalid limits %#", (limits) => {
+		const result = changeApiKeyLimits({
+			key: activeKey({ expiresAt: "2026-04-01T00:00:00.000Z" }),
+			limits,
+			occurredAt: ISSUED_AT,
+			operatorSubject: OPERATOR_SUBJECT,
+		});
+
+		expect(result).toEqual({ kind: "invalid_limits" });
+	});
+});
+
+function activeKey(overrides: Partial<ApiKeyLifecycleRecord>): ApiKeyLifecycleRecord {
+	return {
+		customerId: CUSTOMER_ID,
+		environment: "test",
+		expiresAt: "2026-04-01T00:00:00.000Z",
+		issuedAt: "2026-01-01T00:00:00.000Z",
+		limits: DEFAULT_API_KEY_LIMITS,
+		publicId: PUBLIC_ID,
+		revokedAt: null,
+		rotationOverlapUntil: null,
+		rotationParentId: null,
+		status: "active",
+		...overrides,
+	};
+}

--- a/src/admin/key-lifecycle.ts
+++ b/src/admin/key-lifecycle.ts
@@ -1,0 +1,280 @@
+import type { ApiKeyPublicId } from "../auth/api-key.js";
+
+const SECRET_BYTE_LENGTH = 32;
+const DAY_MILLISECONDS = 24 * 60 * 60 * 1_000;
+const DEFAULT_KEY_LIFETIME_MILLISECONDS = 90 * DAY_MILLISECONDS;
+const MAX_ROTATION_OVERLAP_MILLISECONDS = 7 * DAY_MILLISECONDS;
+
+declare const apiKeyTokenBrand: unique symbol;
+
+export type KeyEnvironment = "production" | "test";
+export type ApiKeyToken = string & { readonly [apiKeyTokenBrand]: "ApiKeyToken" };
+
+export type ApiKeyLimits = {
+	readonly minute: number;
+	readonly day: number;
+};
+
+export const DEFAULT_API_KEY_LIMITS = {
+	minute: 60,
+	day: 1_000,
+} as const satisfies ApiKeyLimits;
+
+export type ApiKeyLifecycleRecord = {
+	readonly customerId: string;
+	readonly environment: KeyEnvironment;
+	readonly expiresAt: string;
+	readonly issuedAt: string;
+	readonly limits: ApiKeyLimits;
+	readonly publicId: ApiKeyPublicId;
+	readonly revokedAt: string | null;
+	readonly rotationOverlapUntil: string | null;
+	readonly rotationParentId: ApiKeyPublicId | null;
+	readonly status: "active" | "revoked";
+};
+
+/** A credential response body is the only permitted consumer of this value. */
+export type OneTimePlaintextCredential = {
+	readonly kind: "one_time_plaintext_credential";
+	readonly token: ApiKeyToken;
+};
+
+export type SanitizedAuditAction =
+	| "key_issued"
+	| "key_rotated"
+	| "key_revoked"
+	| "key_limits_changed";
+
+/** This deliberately cannot carry a plaintext token, secret, HMAC, or request payload. */
+export type SanitizedAuditEvent = {
+	readonly action: SanitizedAuditAction;
+	readonly actorSubject: string;
+	readonly customerId: string;
+	readonly keyPublicId: ApiKeyPublicId;
+	readonly occurredAt: string;
+};
+
+type KeyMaterial = {
+	readonly publicId: ApiKeyPublicId;
+	readonly secret: Uint8Array;
+};
+
+export type IssueApiKeyInput = KeyMaterial & {
+	readonly customerId: string;
+	readonly environment: KeyEnvironment;
+	readonly issuedAt: Date;
+	readonly limits?: ApiKeyLimits | undefined;
+	readonly operatorSubject: string;
+};
+
+export type RotateApiKeyInput = KeyMaterial & {
+	readonly issuedAt: Date;
+	readonly operatorSubject: string;
+	readonly priorKey: ApiKeyLifecycleRecord;
+};
+
+export type RevokeApiKeyInput = {
+	readonly key: ApiKeyLifecycleRecord;
+	readonly operatorSubject: string;
+	readonly revokedAt: Date;
+};
+
+export type ChangeApiKeyLimitsInput = {
+	readonly key: ApiKeyLifecycleRecord;
+	readonly limits: ApiKeyLimits;
+	readonly occurredAt: Date;
+	readonly operatorSubject: string;
+};
+
+export type KeyLifecycleError =
+	| { readonly kind: "invalid_secret_length"; readonly receivedByteLength: number }
+	| { readonly kind: "invalid_limits" }
+	| { readonly kind: "key_not_rotatable" };
+
+export type IssueApiKeyResult =
+	| {
+			readonly kind: "issued";
+			readonly auditEvent: SanitizedAuditEvent;
+			readonly key: ApiKeyLifecycleRecord;
+			readonly plaintextCredential: OneTimePlaintextCredential;
+	  }
+	| KeyLifecycleError;
+
+export type RotateApiKeyResult =
+	| {
+			readonly kind: "rotated";
+			readonly auditEvent: SanitizedAuditEvent;
+			readonly newKey: ApiKeyLifecycleRecord;
+			readonly plaintextCredential: OneTimePlaintextCredential;
+			readonly priorKey: ApiKeyLifecycleRecord;
+	  }
+	| KeyLifecycleError;
+
+export type RevokeApiKeyResult = {
+	readonly kind: "revoked";
+	readonly auditEvent: SanitizedAuditEvent;
+	readonly key: ApiKeyLifecycleRecord;
+};
+
+export type ChangeApiKeyLimitsResult =
+	| {
+			readonly kind: "limits_changed";
+			readonly auditEvent: SanitizedAuditEvent;
+			readonly key: ApiKeyLifecycleRecord;
+	  }
+	| Extract<KeyLifecycleError, { readonly kind: "invalid_limits" }>;
+
+/**
+ * Turns entropy supplied by the Worker shell into a credential. This pure module never
+ * generates or persists secret material; callers must use cryptographically secure entropy.
+ */
+export function issueApiKey(input: IssueApiKeyInput): IssueApiKeyResult {
+	const limits = input.limits ?? DEFAULT_API_KEY_LIMITS;
+	if (!areValidLimits(limits)) return { kind: "invalid_limits" };
+	const credential = createOneTimePlaintextCredential(input.environment, input);
+	if (credential.kind === "invalid_secret_length") return credential;
+
+	const key = createActiveKey({
+		customerId: input.customerId,
+		environment: input.environment,
+		expiresAt: expiryAt(input.issuedAt, DEFAULT_KEY_LIFETIME_MILLISECONDS),
+		issuedAt: input.issuedAt.toISOString(),
+		limits,
+		publicId: input.publicId,
+		rotationParentId: null,
+	});
+	return {
+		kind: "issued",
+		key,
+		plaintextCredential: credential,
+		auditEvent: createAuditEvent("key_issued", input.operatorSubject, key, input.issuedAt),
+	};
+}
+
+export function rotateApiKey(input: RotateApiKeyInput): RotateApiKeyResult {
+	if (input.priorKey.status !== "active" || input.priorKey.revokedAt !== null) {
+		return { kind: "key_not_rotatable" };
+	}
+	const credential = createOneTimePlaintextCredential(input.priorKey.environment, input);
+	if (credential.kind === "invalid_secret_length") return credential;
+
+	const sevenDaysAfterIssue = expiryAt(input.issuedAt, MAX_ROTATION_OVERLAP_MILLISECONDS);
+	const overlapUntil = earliestTimestamp(input.priorKey.expiresAt, sevenDaysAfterIssue);
+	const priorKey = {
+		...input.priorKey,
+		expiresAt: overlapUntil,
+		rotationOverlapUntil: overlapUntil,
+	};
+	const newKey = createActiveKey({
+		customerId: input.priorKey.customerId,
+		environment: input.priorKey.environment,
+		expiresAt: expiryAt(input.issuedAt, DEFAULT_KEY_LIFETIME_MILLISECONDS),
+		issuedAt: input.issuedAt.toISOString(),
+		limits: input.priorKey.limits,
+		publicId: input.publicId,
+		rotationParentId: input.priorKey.publicId,
+	});
+	return {
+		kind: "rotated",
+		newKey,
+		plaintextCredential: credential,
+		priorKey,
+		auditEvent: createAuditEvent("key_rotated", input.operatorSubject, newKey, input.issuedAt),
+	};
+}
+
+export function revokeApiKey(input: RevokeApiKeyInput): RevokeApiKeyResult {
+	const key = {
+		...input.key,
+		revokedAt: input.revokedAt.toISOString(),
+		status: "revoked" as const,
+	};
+	return {
+		kind: "revoked",
+		key,
+		auditEvent: createAuditEvent("key_revoked", input.operatorSubject, key, input.revokedAt),
+	};
+}
+
+export function changeApiKeyLimits(input: ChangeApiKeyLimitsInput): ChangeApiKeyLimitsResult {
+	if (!areValidLimits(input.limits)) return { kind: "invalid_limits" };
+	const key = { ...input.key, limits: input.limits };
+	return {
+		kind: "limits_changed",
+		key,
+		auditEvent: createAuditEvent(
+			"key_limits_changed",
+			input.operatorSubject,
+			key,
+			input.occurredAt,
+		),
+	};
+}
+
+function createOneTimePlaintextCredential(
+	environment: KeyEnvironment,
+	material: KeyMaterial,
+):
+	| OneTimePlaintextCredential
+	| Extract<KeyLifecycleError, { readonly kind: "invalid_secret_length" }> {
+	if (material.secret.byteLength !== SECRET_BYTE_LENGTH) {
+		return { kind: "invalid_secret_length", receivedByteLength: material.secret.byteLength };
+	}
+	const prefix = environment === "production" ? "lc_live" : "lc_test";
+	const token = `${prefix}_${material.publicId}_${encodeBase64Url(material.secret)}` as ApiKeyToken;
+	return { kind: "one_time_plaintext_credential", token };
+}
+
+function createActiveKey(input: {
+	readonly customerId: string;
+	readonly environment: KeyEnvironment;
+	readonly expiresAt: string;
+	readonly issuedAt: string;
+	readonly limits: ApiKeyLimits;
+	readonly publicId: ApiKeyPublicId;
+	readonly rotationParentId: ApiKeyPublicId | null;
+}): ApiKeyLifecycleRecord {
+	return {
+		...input,
+		revokedAt: null,
+		rotationOverlapUntil: null,
+		status: "active",
+	};
+}
+
+function createAuditEvent(
+	action: SanitizedAuditAction,
+	actorSubject: string,
+	key: ApiKeyLifecycleRecord,
+	occurredAt: Date,
+): SanitizedAuditEvent {
+	return {
+		action,
+		actorSubject,
+		customerId: key.customerId,
+		keyPublicId: key.publicId,
+		occurredAt: occurredAt.toISOString(),
+	};
+}
+
+function areValidLimits(limits: ApiKeyLimits): boolean {
+	return (
+		Number.isSafeInteger(limits.minute) &&
+		limits.minute > 0 &&
+		Number.isSafeInteger(limits.day) &&
+		limits.day > 0
+	);
+}
+
+function expiryAt(from: Date, durationMilliseconds: number): string {
+	return new Date(from.getTime() + durationMilliseconds).toISOString();
+}
+
+function earliestTimestamp(left: string, right: string): string {
+	return Date.parse(left) <= Date.parse(right) ? left : right;
+}
+
+function encodeBase64Url(bytes: Uint8Array): string {
+	const base64 = btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""));
+	return base64.replaceAll("+", "-").replaceAll("/", "_").replace(/=+$/u, "");
+}

--- a/src/admin/key-store.ts
+++ b/src/admin/key-store.ts
@@ -1,0 +1,267 @@
+import type { ApiKeyPublicId } from "../auth/api-key.js";
+import type {
+	ApiKeyLifecycleRecord,
+	ApiKeyLimits,
+	KeyEnvironment,
+	SanitizedAuditEvent,
+} from "./key-lifecycle.js";
+
+export type AdminKeyIssue = {
+	readonly key: ApiKeyLifecycleRecord;
+	readonly hmacSha256Hex: string;
+	readonly audit: SanitizedAuditEvent;
+};
+
+export type AdminKeyRotation = AdminKeyIssue & {
+	readonly priorKey: ApiKeyLifecycleRecord;
+};
+
+export type AdminKeyRevocation = {
+	readonly key: ApiKeyLifecycleRecord;
+	readonly audit: SanitizedAuditEvent;
+};
+
+export type AdminKeyLimitChange = AdminKeyRevocation;
+
+export type StoredAdminKey = ApiKeyLifecycleRecord & {
+	readonly hmacSha256Hex: string;
+};
+
+export interface AdminKeyStore {
+	issue(input: AdminKeyIssue): Promise<void>;
+	rotate(input: AdminKeyRotation): Promise<void>;
+	revoke(input: AdminKeyRevocation): Promise<void>;
+	changeLimits(input: AdminKeyLimitChange): Promise<void>;
+	find(publicId: ApiKeyPublicId): Promise<StoredAdminKey | null>;
+	purgeExpired(retainedAt: Date): Promise<void>;
+}
+
+export function createAdminKeyStore(database: D1Database): AdminKeyStore {
+	return {
+		issue: async (input) => {
+			await database.batch([
+				database
+					.prepare(
+						"INSERT INTO customers (id, retired_at, retention_expires_at) VALUES (?1, NULL, NULL) ON CONFLICT(id) DO UPDATE SET retired_at = NULL, retention_expires_at = NULL",
+					)
+					.bind(input.key.customerId),
+				...keyInsertStatements(database, input),
+			]);
+		},
+		rotate: async (input) => {
+			const parent = input.priorKey;
+			const child = input.key;
+			const results = await database.batch([
+				database
+					.prepare(
+						"INSERT INTO api_key_records (public_id, customer_id, environment, hmac_sha256_hex, status, issued_at, expires_at, rotation_parent_id, rotation_overlap_until, minute_limit, day_limit, retention_expires_at) SELECT ?1, ?2, ?3, ?4, 'active', ?5, ?6, ?7, NULL, ?8, ?9, ?10 WHERE EXISTS (SELECT 1 FROM api_key_records WHERE public_id = ?7 AND customer_id = ?2 AND environment = ?3 AND status = 'active')",
+					)
+					.bind(
+						child.publicId,
+						child.customerId,
+						child.environment,
+						input.hmacSha256Hex,
+						child.issuedAt,
+						child.expiresAt,
+						parent.publicId,
+						child.limits.minute,
+						child.limits.day,
+						retentionAt(child.expiresAt),
+					),
+				parentUpdateStatement(database, parent, parent.rotationOverlapUntil),
+				...auditStatements(database, input.audit, child, {
+					status: "active",
+					publicId: child.publicId,
+				}),
+			]);
+			if ((results[0]?.meta.changes ?? 0) !== 1) throw new AdminKeyNotFoundError(parent.publicId);
+		},
+		revoke: async (input) => {
+			const key = input.key;
+			const revokedAt = key.revokedAt ?? input.audit.occurredAt;
+			const results = await database.batch([
+				database
+					.prepare(
+						"UPDATE api_key_records SET status = 'revoked', revoked_at = ?1, rotation_overlap_until = NULL, retention_expires_at = ?2 WHERE public_id = ?3 AND status = 'active'",
+					)
+					.bind(revokedAt, retentionAt(revokedAt), key.publicId),
+				...auditStatements(database, input.audit, key, {
+					status: "revoked",
+					publicId: key.publicId,
+					revokedAt: revokedAt,
+				}),
+			]);
+			if ((results[0]?.meta.changes ?? 0) !== 1) throw new AdminKeyNotFoundError(key.publicId);
+		},
+		changeLimits: async (input) => {
+			const key = input.key;
+			const results = await database.batch([
+				database
+					.prepare(
+						"UPDATE api_key_records SET minute_limit = ?1, day_limit = ?2 WHERE public_id = ?3 AND status = 'active'",
+					)
+					.bind(key.limits.minute, key.limits.day, key.publicId),
+				...auditStatements(database, input.audit, key, {
+					status: "active",
+					publicId: key.publicId,
+				}),
+			]);
+			if ((results[0]?.meta.changes ?? 0) !== 1) throw new AdminKeyNotFoundError(key.publicId);
+		},
+		find: async (publicId) => {
+			const row = await database
+				.prepare(
+					"SELECT customer_id, environment, expires_at, issued_at, minute_limit, day_limit, public_id, revoked_at, rotation_overlap_until, rotation_parent_id, status, hmac_sha256_hex FROM api_key_records WHERE public_id = ?1 LIMIT 1",
+				)
+				.bind(publicId)
+				.first<StoredKeyRow>();
+			return row === null ? null : fromStoredRow(row);
+		},
+		purgeExpired: async (retainedAt) => {
+			const timestamp = retainedAt.toISOString();
+			await database.batch([
+				database
+					.prepare("DELETE FROM admin_audit_events WHERE retention_expires_at <= ?1")
+					.bind(timestamp),
+				database
+					.prepare("DELETE FROM api_key_records WHERE retention_expires_at <= ?1")
+					.bind(timestamp),
+			]);
+		},
+	};
+}
+
+export class AdminKeyNotFoundError extends Error {
+	readonly name = "AdminKeyNotFoundError";
+
+	constructor(readonly publicId: ApiKeyPublicId) {
+		super(`api key ${publicId} is unavailable`);
+	}
+}
+
+function keyInsertStatements(
+	database: D1Database,
+	input: AdminKeyIssue,
+): readonly D1PreparedStatement[] {
+	const key = input.key;
+	return [
+		database
+			.prepare(
+				"INSERT INTO api_key_records (public_id, customer_id, environment, hmac_sha256_hex, status, issued_at, expires_at, rotation_parent_id, rotation_overlap_until, minute_limit, day_limit, retention_expires_at) VALUES (?1, ?2, ?3, ?4, 'active', ?5, ?6, NULL, NULL, ?7, ?8, ?9)",
+			)
+			.bind(
+				key.publicId,
+				key.customerId,
+				key.environment,
+				input.hmacSha256Hex,
+				key.issuedAt,
+				key.expiresAt,
+				key.limits.minute,
+				key.limits.day,
+				retentionAt(key.expiresAt),
+			),
+		...auditStatements(database, input.audit, key, { status: "active", publicId: key.publicId }),
+	];
+}
+
+function parentUpdateStatement(
+	database: D1Database,
+	parent: ApiKeyLifecycleRecord,
+	overlap: string | null,
+): D1PreparedStatement {
+	const expiresAt = overlap ?? parent.expiresAt;
+	return database
+		.prepare(
+			"UPDATE api_key_records SET expires_at = ?1, rotation_overlap_until = ?2, retention_expires_at = ?3 WHERE public_id = ?4 AND customer_id = ?5 AND environment = ?6 AND status = 'active'",
+		)
+		.bind(
+			expiresAt,
+			overlap,
+			retentionAt(expiresAt),
+			parent.publicId,
+			parent.customerId,
+			parent.environment,
+		);
+}
+
+function auditStatements(
+	database: D1Database,
+	audit: SanitizedAuditEvent,
+	key: ApiKeyLifecycleRecord,
+	guard: AuditGuard,
+): readonly D1PreparedStatement[] {
+	const metadata =
+		audit.action === "key_rotated" && key.rotationParentId !== null
+			? JSON.stringify({ rotationParentId: key.rotationParentId })
+			: "{}";
+	const auditRetention =
+		audit.action === "key_revoked" ? retentionAt(audit.occurredAt) : retentionAt(key.expiresAt);
+	return [
+		database
+			.prepare(
+				"INSERT INTO admin_audit_events (id, action, actor_subject, customer_id, public_id, environment, occurred_at, retention_expires_at, metadata_json) SELECT ?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9 WHERE EXISTS (SELECT 1 FROM api_key_records WHERE public_id = ?10 AND status = ?11 AND (?12 IS NULL OR revoked_at = ?12))",
+			)
+			.bind(
+				crypto.randomUUID(),
+				audit.action,
+				sanitizeActor(audit.actorSubject),
+				audit.customerId,
+				audit.keyPublicId,
+				key.environment,
+				audit.occurredAt,
+				auditRetention,
+				metadata,
+				guard.publicId,
+				guard.status,
+				guard.revokedAt ?? null,
+			),
+	];
+}
+
+type AuditGuard = {
+	readonly status: "active" | "revoked";
+	readonly publicId: ApiKeyPublicId;
+	readonly revokedAt?: string;
+};
+
+type StoredKeyRow = {
+	readonly customer_id: string;
+	readonly environment: KeyEnvironment;
+	readonly expires_at: string;
+	readonly issued_at: string;
+	readonly minute_limit: number;
+	readonly day_limit: number;
+	readonly public_id: ApiKeyPublicId;
+	readonly revoked_at: string | null;
+	readonly rotation_overlap_until: string | null;
+	readonly rotation_parent_id: ApiKeyPublicId | null;
+	readonly status: "active" | "revoked";
+	readonly hmac_sha256_hex: string;
+};
+
+function fromStoredRow(row: StoredKeyRow): StoredAdminKey {
+	return {
+		customerId: row.customer_id,
+		environment: row.environment,
+		expiresAt: row.expires_at,
+		issuedAt: row.issued_at,
+		limits: { minute: row.minute_limit, day: row.day_limit },
+		publicId: row.public_id,
+		revokedAt: row.revoked_at,
+		rotationOverlapUntil: row.rotation_overlap_until,
+		rotationParentId: row.rotation_parent_id,
+		status: row.status,
+		hmacSha256Hex: row.hmac_sha256_hex,
+	};
+}
+
+function retentionAt(value: string): string {
+	return new Date(Date.parse(value) + 365 * 24 * 60 * 60 * 1_000).toISOString();
+}
+
+function sanitizeActor(value: string): string {
+	return Array.from(value)
+		.filter((character) => character >= " " && character !== "\u007f")
+		.join("")
+		.slice(0, 256);
+}

--- a/src/admin/key-store.ts
+++ b/src/admin/key-store.ts
@@ -33,7 +33,6 @@ export interface AdminKeyStore {
 	revoke(input: AdminKeyRevocation): Promise<void>;
 	changeLimits(input: AdminKeyLimitChange): Promise<void>;
 	find(publicId: ApiKeyPublicId): Promise<StoredAdminKey | null>;
-	purgeExpired(retainedAt: Date): Promise<void>;
 }
 
 export function createAdminKeyStore(database: D1Database): AdminKeyStore {
@@ -54,7 +53,7 @@ export function createAdminKeyStore(database: D1Database): AdminKeyStore {
 			const results = await database.batch([
 				database
 					.prepare(
-						"INSERT INTO api_key_records (public_id, customer_id, environment, hmac_sha256_hex, status, issued_at, expires_at, rotation_parent_id, rotation_overlap_until, minute_limit, day_limit, retention_expires_at) SELECT ?1, ?2, ?3, ?4, 'active', ?5, ?6, ?7, NULL, ?8, ?9, ?10 WHERE EXISTS (SELECT 1 FROM api_key_records WHERE public_id = ?7 AND customer_id = ?2 AND environment = ?3 AND status = 'active')",
+						"INSERT INTO api_key_records (public_id, customer_id, environment, hmac_sha256_hex, status, issued_at, expires_at, rotation_parent_id, rotation_overlap_until, minute_limit, day_limit, retention_expires_at) SELECT ?1, ?2, ?3, ?4, 'active', ?5, ?6, ?7, NULL, ?8, ?9, ?10 WHERE EXISTS (SELECT 1 FROM api_key_records WHERE public_id = ?7 AND customer_id = ?2 AND environment = ?3 AND status = 'active' AND rotation_overlap_until IS NULL)",
 					)
 					.bind(
 						child.publicId,
@@ -74,7 +73,8 @@ export function createAdminKeyStore(database: D1Database): AdminKeyStore {
 					publicId: child.publicId,
 				}),
 			]);
-			if ((results[0]?.meta.changes ?? 0) !== 1) throw new AdminKeyNotFoundError(parent.publicId);
+			if ((results[0]?.meta.changes ?? 0) !== 1)
+				throw new AdminKeyRotationConflictError(parent.publicId);
 		},
 		revoke: async (input) => {
 			const key = input.key;
@@ -117,18 +117,15 @@ export function createAdminKeyStore(database: D1Database): AdminKeyStore {
 				.first<StoredKeyRow>();
 			return row === null ? null : fromStoredRow(row);
 		},
-		purgeExpired: async (retainedAt) => {
-			const timestamp = retainedAt.toISOString();
-			await database.batch([
-				database
-					.prepare("DELETE FROM admin_audit_events WHERE retention_expires_at <= ?1")
-					.bind(timestamp),
-				database
-					.prepare("DELETE FROM api_key_records WHERE retention_expires_at <= ?1")
-					.bind(timestamp),
-			]);
-		},
 	};
+}
+
+export class AdminKeyRotationConflictError extends Error {
+	readonly name = "AdminKeyRotationConflictError";
+
+	constructor(readonly publicId: ApiKeyPublicId) {
+		super(`api key ${publicId} has already been rotated`);
+	}
 }
 
 export class AdminKeyNotFoundError extends Error {
@@ -172,7 +169,7 @@ function parentUpdateStatement(
 	const expiresAt = overlap ?? parent.expiresAt;
 	return database
 		.prepare(
-			"UPDATE api_key_records SET expires_at = ?1, rotation_overlap_until = ?2, retention_expires_at = ?3 WHERE public_id = ?4 AND customer_id = ?5 AND environment = ?6 AND status = 'active'",
+			"UPDATE api_key_records SET expires_at = ?1, rotation_overlap_until = ?2, retention_expires_at = ?3 WHERE public_id = ?4 AND customer_id = ?5 AND environment = ?6 AND status = 'active' AND rotation_overlap_until IS NULL",
 		)
 		.bind(
 			expiresAt,

--- a/src/admin/worker.ts
+++ b/src/admin/worker.ts
@@ -1,0 +1,273 @@
+import { z } from "zod";
+import { createApiKeyPublicId } from "../auth/api-key.js";
+import { verifyAccessIdentity, type AccessEnvironment, type AccessIdentity } from "./access.js";
+import { apiKeyPepper, hmacSha256Hex, secretBytes } from "./credentials.js";
+import {
+	changeApiKeyLimits,
+	issueApiKey,
+	revokeApiKey,
+	rotateApiKey,
+	type ApiKeyLifecycleRecord,
+} from "./key-lifecycle.js";
+import { AdminKeyNotFoundError, createAdminKeyStore } from "./key-store.js";
+
+const ADMIN_ACTION_SCHEMA = z.enum(["rotate", "revoke", "limits"]);
+const ISSUE_REQUEST_SCHEMA = z.object({
+	customerId: z.string().min(1).max(256),
+	limits: z
+		.object({ day: z.number().int().positive(), minute: z.number().int().positive() })
+		.optional(),
+});
+const LIMITS_REQUEST_SCHEMA = z.object({
+	day: z.number().int().positive(),
+	minute: z.number().int().positive(),
+});
+
+export type Env = AccessEnvironment & {
+	readonly API_KEY_PEPPER?: string;
+	readonly DB: D1Database;
+	readonly KEY_ENVIRONMENT: string;
+};
+
+type Route =
+	| { readonly kind: "issue" }
+	| { readonly kind: "rotate"; readonly publicId: string }
+	| { readonly kind: "revoke"; readonly publicId: string }
+	| { readonly kind: "limits"; readonly publicId: string }
+	| { readonly kind: "not_found" };
+
+const adminWorker = {
+	async fetch(request: Request, env: Env): Promise<Response> {
+		const identity = await verifyAccessIdentity(request, env);
+		if (identity === null) return unauthorizedResponse();
+
+		const route = parseRoute(request);
+		switch (route.kind) {
+			case "issue":
+				return issue(request, env, identity);
+			case "rotate":
+				return rotate(route.publicId, env, identity);
+			case "revoke":
+				return revoke(route.publicId, env, identity);
+			case "limits":
+				return changeLimits(request, route.publicId, env, identity);
+			case "not_found":
+				return notFoundResponse();
+			default:
+				return assertNever(route);
+		}
+	},
+} satisfies ExportedHandler<Env>;
+
+export default adminWorker;
+
+async function issue(request: Request, env: Env, identity: AccessIdentity): Promise<Response> {
+	const parsed = await parseJson(request, ISSUE_REQUEST_SCHEMA);
+	if (parsed === null) return badRequestResponse();
+	const environment = parseKeyEnvironment(env.KEY_ENVIRONMENT);
+	const pepper = apiKeyPepper(env.API_KEY_PEPPER);
+	if (environment === null || pepper === null) return internalErrorResponse();
+
+	const decision = issueApiKey({
+		customerId: parsed.customerId,
+		environment,
+		issuedAt: new Date(),
+		limits: parsed.limits,
+		operatorSubject: identity.subject,
+		publicId: createApiKeyPublicId(crypto.randomUUID()),
+		secret: secretBytes(),
+	});
+	if (decision.kind !== "issued") return internalErrorResponse();
+
+	try {
+		await createAdminKeyStore(env.DB).issue({
+			key: decision.key,
+			hmacSha256Hex: await hmacSha256Hex(pepper, decision.plaintextCredential.token),
+			audit: decision.auditEvent,
+		});
+		return credentialResponse(decision.key, decision.plaintextCredential.token);
+	} catch {
+		return internalErrorResponse();
+	}
+}
+
+async function rotate(publicId: string, env: Env, identity: AccessIdentity): Promise<Response> {
+	const key = parsePublicId(publicId);
+	const pepper = apiKeyPepper(env.API_KEY_PEPPER);
+	if (key === null) return badRequestResponse();
+	if (pepper === null) return internalErrorResponse();
+	try {
+		const store = createAdminKeyStore(env.DB);
+		const prior = await store.find(key);
+		if (prior === null) return notFoundResponse();
+		const decision = rotateApiKey({
+			issuedAt: new Date(),
+			operatorSubject: identity.subject,
+			priorKey: withoutHash(prior),
+			publicId: createApiKeyPublicId(crypto.randomUUID()),
+			secret: secretBytes(),
+		});
+		if (decision.kind === "key_not_rotatable") return conflictResponse();
+		if (decision.kind !== "rotated") return internalErrorResponse();
+		await store.rotate({
+			key: decision.newKey,
+			priorKey: decision.priorKey,
+			hmacSha256Hex: await hmacSha256Hex(pepper, decision.plaintextCredential.token),
+			audit: decision.auditEvent,
+		});
+		return credentialResponse(decision.newKey, decision.plaintextCredential.token);
+	} catch {
+		return internalErrorResponse();
+	}
+}
+
+async function revoke(publicId: string, env: Env, identity: AccessIdentity): Promise<Response> {
+	const key = parsePublicId(publicId);
+	if (key === null) return badRequestResponse();
+	try {
+		const store = createAdminKeyStore(env.DB);
+		const prior = await store.find(key);
+		if (prior === null) return notFoundResponse();
+		const decision = revokeApiKey({
+			key: withoutHash(prior),
+			operatorSubject: identity.subject,
+			revokedAt: new Date(),
+		});
+		await store.revoke({ key: decision.key, audit: decision.auditEvent });
+		return Response.json({ key: responseKey(decision.key) }, responseOptions(200));
+	} catch (error) {
+		if (error instanceof AdminKeyNotFoundError) return notFoundResponse();
+		return internalErrorResponse();
+	}
+}
+
+async function changeLimits(
+	request: Request,
+	publicId: string,
+	env: Env,
+	identity: AccessIdentity,
+): Promise<Response> {
+	const parsed = await parseJson(request, LIMITS_REQUEST_SCHEMA);
+	const key = parsePublicId(publicId);
+	if (parsed === null || key === null) return badRequestResponse();
+	try {
+		const store = createAdminKeyStore(env.DB);
+		const prior = await store.find(key);
+		if (prior === null) return notFoundResponse();
+		const decision = changeApiKeyLimits({
+			key: withoutHash(prior),
+			limits: parsed,
+			occurredAt: new Date(),
+			operatorSubject: identity.subject,
+		});
+		if (decision.kind !== "limits_changed") return badRequestResponse();
+		await store.changeLimits({ key: decision.key, audit: decision.auditEvent });
+		return Response.json({ key: responseKey(decision.key) }, responseOptions(200));
+	} catch (error) {
+		if (error instanceof AdminKeyNotFoundError) return notFoundResponse();
+		return internalErrorResponse();
+	}
+}
+
+function parseRoute(request: Request): Route {
+	const pathname = new URL(request.url).pathname;
+	if (request.method === "POST" && pathname === "/v1/keys") return { kind: "issue" };
+	const match = /^\/v1\/keys\/([^/]+)\/(rotate|revoke|limits)$/u.exec(pathname);
+	if (match === null) return { kind: "not_found" };
+	const publicId = match[1];
+	const action = ADMIN_ACTION_SCHEMA.safeParse(match[2]);
+	if (publicId === undefined || !action.success) return { kind: "not_found" };
+	const actionValue = action.data;
+	switch (actionValue) {
+		case "rotate":
+			return request.method === "POST" ? { kind: "rotate", publicId } : { kind: "not_found" };
+		case "revoke":
+			return request.method === "POST" ? { kind: "revoke", publicId } : { kind: "not_found" };
+		case "limits":
+			return request.method === "PUT" ? { kind: "limits", publicId } : { kind: "not_found" };
+		default:
+			return assertNever(actionValue);
+	}
+}
+
+async function parseJson<T>(request: Request, schema: z.ZodType<T>): Promise<T | null> {
+	if (request.headers.get("content-type")?.split(";", 1)[0] !== "application/json") return null;
+	try {
+		return schema.safeParse(await request.json()).data ?? null;
+	} catch {
+		return null;
+	}
+}
+
+function credentialResponse(key: ApiKeyLifecycleRecord, token: string): Response {
+	return Response.json({ credential: token, key: responseKey(key) }, responseOptions(201));
+}
+
+function responseKey(key: ApiKeyLifecycleRecord): object {
+	return {
+		customerId: key.customerId,
+		environment: key.environment,
+		expiresAt: key.expiresAt,
+		limits: key.limits,
+		publicId: key.publicId,
+		rotationOverlapUntil: key.rotationOverlapUntil,
+		rotationParentId: key.rotationParentId,
+		status: key.status,
+	};
+}
+
+function responseOptions(status: number): ResponseInit {
+	return {
+		status,
+		headers: {
+			"cache-control": "no-store",
+			"content-type": "application/json",
+			pragma: "no-cache",
+			"referrer-policy": "no-referrer",
+			"x-content-type-options": "nosniff",
+		},
+	};
+}
+
+function unauthorizedResponse(): Response {
+	return new Response('{"error":"Unauthorized"}', responseOptions(401));
+}
+
+function badRequestResponse(): Response {
+	return new Response('{"error":"Bad Request"}', responseOptions(400));
+}
+
+function conflictResponse(): Response {
+	return new Response('{"error":"Conflict"}', responseOptions(409));
+}
+
+function notFoundResponse(): Response {
+	return new Response('{"error":"Not Found"}', responseOptions(404));
+}
+
+function internalErrorResponse(): Response {
+	return new Response('{"error":"Internal Server Error"}', responseOptions(500));
+}
+
+function parseKeyEnvironment(value: string): "production" | "test" | null {
+	return value === "production" || value === "test" ? value : null;
+}
+
+function parsePublicId(value: string) {
+	try {
+		return createApiKeyPublicId(value);
+	} catch {
+		return null;
+	}
+}
+
+function withoutHash(
+	key: ApiKeyLifecycleRecord & { readonly hmacSha256Hex: string },
+): ApiKeyLifecycleRecord {
+	const { hmacSha256Hex: _, ...record } = key;
+	return record;
+}
+
+function assertNever(value: never): never {
+	throw new Error(`Unexpected variant: ${String(value)}`);
+}

--- a/src/admin/worker.ts
+++ b/src/admin/worker.ts
@@ -10,6 +10,7 @@ import {
 	type ApiKeyLifecycleRecord,
 } from "./key-lifecycle.js";
 import { AdminKeyNotFoundError, createAdminKeyStore } from "./key-store.js";
+import { AdminKeyRotationConflictError } from "./key-store.js";
 
 const ADMIN_ACTION_SCHEMA = z.enum(["rotate", "revoke", "limits"]);
 const ISSUE_REQUEST_SCHEMA = z.object({
@@ -116,8 +117,10 @@ async function rotate(publicId: string, env: Env, identity: AccessIdentity): Pro
 			audit: decision.auditEvent,
 		});
 		return credentialResponse(decision.newKey, decision.plaintextCredential.token);
-	} catch {
-		return internalErrorResponse();
+	} catch (error) {
+		return error instanceof AdminKeyRotationConflictError
+			? conflictResponse()
+			: internalErrorResponse();
 	}
 }
 

--- a/test/admin-config.integration.test.ts
+++ b/test/admin-config.integration.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import adminWranglerConfig from "../wrangler.admin.jsonc?raw";
+
+type AdminWranglerConfig = {
+	readonly env: {
+		readonly test: {
+			readonly routes: readonly unknown[];
+			readonly vars: { readonly KEY_ENVIRONMENT: string };
+		};
+	};
+	readonly vars: { readonly KEY_ENVIRONMENT: string };
+};
+
+describe("admin Worker configuration", () => {
+	it("uses production keys by default while keeping the workerd test environment isolated", () => {
+		// Given: the committed standalone admin Wrangler configuration.
+		const configuration = JSON.parse(
+			stripJsoncComments(adminWranglerConfig),
+		) as AdminWranglerConfig;
+
+		// When: production defaults and the named test environment are inspected.
+		const testEnvironment = configuration.env.test;
+
+		// Then: the default cannot issue test-prefixed keys, and test has no production route.
+		expect(configuration.vars.KEY_ENVIRONMENT).toBe("production");
+		expect(testEnvironment.vars.KEY_ENVIRONMENT).toBe("test");
+		expect(testEnvironment.routes).toEqual([]);
+	});
+});
+
+function stripJsoncComments(value: string): string {
+	return value.replaceAll(/^\s*\/\/.*$/gmu, "");
+}

--- a/test/admin-key-store.integration.test.ts
+++ b/test/admin-key-store.integration.test.ts
@@ -1,0 +1,247 @@
+import { env } from "cloudflare:test";
+import { beforeAll, describe, expect, it } from "vitest";
+import migrationOne from "../migrations/0001_api_key_records.sql?raw";
+import migrationTwo from "../migrations/0002_admin_key_lifecycle.sql?raw";
+import type { ApiKeyLifecycleRecord, SanitizedAuditEvent } from "../src/admin/key-lifecycle";
+import {
+	type AdminKeyIssue,
+	type AdminKeyLimitChange,
+	type AdminKeyRevocation,
+	type AdminKeyRotation,
+	createAdminKeyStore,
+} from "../src/admin/key-store";
+import { createApiKeyPublicId } from "../src/auth/api-key";
+
+const now = "2026-08-09T12:00:00.000Z";
+const retention = "2027-11-07T12:00:00.000Z";
+const issuePublicId = createApiKeyPublicId("key-issue");
+const rotatedPublicId = createApiKeyPublicId("key-rotated");
+
+async function applyMigration(sql: string): Promise<void> {
+	for (const query of sql
+		.split(";")
+		.map((statement) => statement.trim())
+		.filter(Boolean)) {
+		await env.DB.prepare(query).run();
+	}
+}
+
+function makeKey(publicId: ApiKeyLifecycleRecord["publicId"]): ApiKeyLifecycleRecord {
+	return {
+		customerId: "customer-issue",
+		environment: "test",
+		expiresAt: "2026-11-07T12:00:00.000Z",
+		issuedAt: now,
+		limits: { minute: 60, day: 1000 },
+		publicId,
+		revokedAt: null,
+		rotationOverlapUntil: null,
+		rotationParentId: null,
+		status: "active",
+	};
+}
+
+function makeAudit(
+	action: SanitizedAuditEvent["action"],
+	publicId: ApiKeyLifecycleRecord["publicId"],
+): SanitizedAuditEvent {
+	return {
+		action,
+		actorSubject: "operator@example.invalid",
+		customerId: "customer-issue",
+		keyPublicId: publicId,
+		occurredAt: now,
+	};
+}
+
+const issuedKey = makeKey(issuePublicId);
+const issue: AdminKeyIssue = {
+	key: issuedKey,
+	hmacSha256Hex: "a".repeat(64),
+	audit: makeAudit("key_issued", issuePublicId),
+};
+
+describe("AdminKeyStore against workerd D1", () => {
+	beforeAll(async () => {
+		await applyMigration(migrationOne);
+		await applyMigration(migrationTwo);
+	});
+
+	it("persists an issued key without a plaintext credential", async () => {
+		const store = createAdminKeyStore(env.DB);
+
+		await store.issue(issue);
+
+		const row = await env.DB.prepare(
+			"SELECT public_id, customer_id, hmac_sha256_hex, status, rotation_parent_id, rotation_overlap_until, minute_limit, day_limit, retention_expires_at FROM api_key_records WHERE public_id = ?1",
+		)
+			.bind(issuePublicId)
+			.first<Record<string, unknown>>();
+		const event = await env.DB.prepare(
+			"SELECT action, actor_subject, public_id, metadata_json FROM admin_audit_events WHERE public_id = ?1",
+		)
+			.bind(issuePublicId)
+			.first<Record<string, unknown>>();
+
+		expect(row).toMatchObject({
+			public_id: issuePublicId,
+			customer_id: issuedKey.customerId,
+			hmac_sha256_hex: issue.hmacSha256Hex,
+			status: "active",
+			rotation_parent_id: null,
+			rotation_overlap_until: null,
+			minute_limit: issuedKey.limits.minute,
+			day_limit: issuedKey.limits.day,
+			retention_expires_at: retention,
+		});
+		expect(JSON.stringify(row)).not.toContain("lc_test_");
+		expect(event).toMatchObject({
+			action: "key_issued",
+			actor_subject: issue.audit.actorSubject,
+			public_id: issuePublicId,
+			metadata_json: "{}",
+		});
+		expect(JSON.stringify(event)).not.toContain("secret");
+	});
+
+	it("persists rotation lineage and bounded overlap atomically", async () => {
+		const priorKey = {
+			...issuedKey,
+			expiresAt: "2026-08-16T12:00:00.000Z",
+			rotationOverlapUntil: "2026-08-16T12:00:00.000Z",
+		};
+		const rotation: AdminKeyRotation = {
+			key: { ...makeKey(rotatedPublicId), rotationParentId: issuePublicId },
+			priorKey,
+			hmacSha256Hex: "b".repeat(64),
+			audit: makeAudit("key_rotated", rotatedPublicId),
+		};
+		const store = createAdminKeyStore(env.DB);
+
+		await store.rotate(rotation);
+
+		const rows = await env.DB.prepare(
+			"SELECT public_id, rotation_parent_id FROM api_key_records WHERE customer_id = ?1 ORDER BY public_id",
+		)
+			.bind(issuedKey.customerId)
+			.all<{ public_id: string; rotation_parent_id: string | null }>();
+		expect(rows.results).toContainEqual({
+			public_id: "key-rotated",
+			rotation_parent_id: "key-issue",
+		});
+	});
+
+	it("does not create a child or audit when the rotation parent is unavailable", async () => {
+		const store = createAdminKeyStore(env.DB);
+		const missingParent = createApiKeyPublicId("key-missing-parent");
+		const child = createApiKeyPublicId("key-no-child");
+		const rotation: AdminKeyRotation = {
+			key: { ...makeKey(child), rotationParentId: missingParent },
+			priorKey: { ...makeKey(missingParent) },
+			hmacSha256Hex: "c".repeat(64),
+			audit: makeAudit("key_rotated", child),
+		};
+
+		await expect(store.rotate(rotation)).rejects.toThrow();
+
+		const persistedChild = await env.DB.prepare(
+			"SELECT public_id FROM api_key_records WHERE public_id = ?1",
+		)
+			.bind(child)
+			.first();
+		const persistedAudit = await env.DB.prepare(
+			"SELECT id FROM admin_audit_events WHERE public_id = ?1",
+		)
+			.bind(child)
+			.first();
+		expect(persistedChild).toBeNull();
+		expect(persistedAudit).toBeNull();
+	});
+
+	it("revokes immediately and records a sanitized audit event", async () => {
+		const store = createAdminKeyStore(env.DB);
+		const key: ApiKeyLifecycleRecord = {
+			...makeKey(rotatedPublicId),
+			rotationParentId: issuePublicId,
+		};
+		const revocation: AdminKeyRevocation = {
+			key: { ...key, revokedAt: now, status: "revoked" },
+			audit: makeAudit("key_revoked", rotatedPublicId),
+		};
+
+		await store.revoke(revocation);
+
+		const row = await env.DB.prepare(
+			"SELECT status, revoked_at, rotation_overlap_until, retention_expires_at FROM api_key_records WHERE public_id = ?1",
+		)
+			.bind(rotatedPublicId)
+			.first<Record<string, unknown>>();
+		const event = await env.DB.prepare(
+			"SELECT action, metadata_json, retention_expires_at FROM admin_audit_events WHERE public_id = ?1 AND action = 'key_revoked'",
+		)
+			.bind(rotatedPublicId)
+			.first<Record<string, unknown>>();
+		expect(row).toMatchObject({
+			status: "revoked",
+			revoked_at: now,
+			rotation_overlap_until: null,
+			retention_expires_at: "2027-08-09T12:00:00.000Z",
+		});
+		expect(event).toMatchObject({
+			action: "key_revoked",
+			metadata_json: "{}",
+			retention_expires_at: "2027-08-09T12:00:00.000Z",
+		});
+	});
+
+	it("changes limits atomically while preserving the key record", async () => {
+		const store = createAdminKeyStore(env.DB);
+		const change: AdminKeyLimitChange = {
+			key: { ...makeKey(issuePublicId), limits: { minute: 12, day: 240 } },
+			audit: makeAudit("key_limits_changed", issuePublicId),
+		};
+
+		await store.changeLimits(change);
+
+		const row = await env.DB.prepare(
+			"SELECT minute_limit, day_limit, hmac_sha256_hex FROM api_key_records WHERE public_id = ?1",
+		)
+			.bind(issuePublicId)
+			.first<Record<string, unknown>>();
+		expect(row).toMatchObject({
+			minute_limit: 12,
+			day_limit: 240,
+			hmac_sha256_hex: "a".repeat(64),
+		});
+	});
+
+	it("rolls back an issue when key insertion fails", async () => {
+		const store = createAdminKeyStore(env.DB);
+		const duplicate: AdminKeyIssue = {
+			...issue,
+			key: { ...issuedKey, customerId: "customer-rolled-back" },
+		};
+
+		await expect(store.issue(duplicate)).rejects.toThrow();
+
+		const customer = await env.DB.prepare("SELECT id FROM customers WHERE id = ?1")
+			.bind("customer-rolled-back")
+			.first();
+		expect(customer).toBeNull();
+	});
+
+	it("removes retained keys and audits only after the retention timestamp", async () => {
+		const store = createAdminKeyStore(env.DB);
+
+		await store.purgeExpired(new Date("2027-11-08T00:00:00.000Z"));
+
+		const key = await env.DB.prepare("SELECT public_id FROM api_key_records WHERE public_id = ?1")
+			.bind(issuePublicId)
+			.first();
+		const audit = await env.DB.prepare("SELECT id FROM admin_audit_events WHERE public_id = ?1")
+			.bind(issuePublicId)
+			.first();
+		expect(key).toBeNull();
+		expect(audit).toBeNull();
+	});
+});

--- a/test/admin-key-store.integration.test.ts
+++ b/test/admin-key-store.integration.test.ts
@@ -1,5 +1,5 @@
 import { env } from "cloudflare:test";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it } from "vitest";
 import migrationOne from "../migrations/0001_api_key_records.sql?raw";
 import migrationTwo from "../migrations/0002_admin_key_lifecycle.sql?raw";
 import type { ApiKeyLifecycleRecord, SanitizedAuditEvent } from "../src/admin/key-lifecycle";
@@ -8,6 +8,7 @@ import {
 	type AdminKeyLimitChange,
 	type AdminKeyRevocation,
 	type AdminKeyRotation,
+	AdminKeyRotationConflictError,
 	createAdminKeyStore,
 } from "../src/admin/key-store";
 import { createApiKeyPublicId } from "../src/auth/api-key";
@@ -54,6 +55,19 @@ function makeAudit(
 	};
 }
 
+function makeRotation(
+	publicId: ApiKeyLifecycleRecord["publicId"],
+	hmacSha256Hex: string,
+): AdminKeyRotation {
+	const overlap = "2026-08-16T12:00:00.000Z";
+	return {
+		key: { ...makeKey(publicId), rotationParentId: issuePublicId },
+		priorKey: { ...issuedKey, expiresAt: overlap, rotationOverlapUntil: overlap },
+		hmacSha256Hex,
+		audit: makeAudit("key_rotated", publicId),
+	};
+}
+
 const issuedKey = makeKey(issuePublicId);
 const issue: AdminKeyIssue = {
 	key: issuedKey,
@@ -62,7 +76,10 @@ const issue: AdminKeyIssue = {
 };
 
 describe("AdminKeyStore against workerd D1", () => {
-	beforeAll(async () => {
+	beforeEach(async () => {
+		await env.DB.prepare("DROP TABLE IF EXISTS admin_audit_events").run();
+		await env.DB.prepare("DROP TABLE IF EXISTS api_key_records").run();
+		await env.DB.prepare("DROP TABLE IF EXISTS customers").run();
 		await applyMigration(migrationOne);
 		await applyMigration(migrationTwo);
 	});
@@ -105,18 +122,9 @@ describe("AdminKeyStore against workerd D1", () => {
 	});
 
 	it("persists rotation lineage and bounded overlap atomically", async () => {
-		const priorKey = {
-			...issuedKey,
-			expiresAt: "2026-08-16T12:00:00.000Z",
-			rotationOverlapUntil: "2026-08-16T12:00:00.000Z",
-		};
-		const rotation: AdminKeyRotation = {
-			key: { ...makeKey(rotatedPublicId), rotationParentId: issuePublicId },
-			priorKey,
-			hmacSha256Hex: "b".repeat(64),
-			audit: makeAudit("key_rotated", rotatedPublicId),
-		};
 		const store = createAdminKeyStore(env.DB);
+		await store.issue(issue);
+		const rotation = makeRotation(rotatedPublicId, "b".repeat(64));
 
 		await store.rotate(rotation);
 
@@ -158,8 +166,37 @@ describe("AdminKeyStore against workerd D1", () => {
 		expect(persistedAudit).toBeNull();
 	});
 
+	it("allows only one concurrent replacement from a parent", async () => {
+		const store = createAdminKeyStore(env.DB);
+		await store.issue(issue);
+		const firstChild = createApiKeyPublicId("key-concurrent-a");
+		const secondChild = createApiKeyPublicId("key-concurrent-b");
+
+		const outcomes = await Promise.allSettled([
+			store.rotate(makeRotation(firstChild, "d".repeat(64))),
+			store.rotate(makeRotation(secondChild, "e".repeat(64))),
+		]);
+
+		const fulfilled = outcomes.filter(
+			(outcome): outcome is PromiseFulfilledResult<void> => outcome.status === "fulfilled",
+		);
+		const rejected = outcomes.find(
+			(outcome): outcome is PromiseRejectedResult => outcome.status === "rejected",
+		);
+		expect(fulfilled).toHaveLength(1);
+		expect(rejected?.reason).toBeInstanceOf(AdminKeyRotationConflictError);
+		const children = await env.DB.prepare(
+			"SELECT COUNT(*) AS count FROM api_key_records WHERE rotation_parent_id = ?1",
+		)
+			.bind(issuePublicId)
+			.first<{ count: number }>();
+		expect(children?.count).toBe(1);
+	});
+
 	it("revokes immediately and records a sanitized audit event", async () => {
 		const store = createAdminKeyStore(env.DB);
+		await store.issue(issue);
+		await store.rotate(makeRotation(rotatedPublicId, "b".repeat(64)));
 		const key: ApiKeyLifecycleRecord = {
 			...makeKey(rotatedPublicId),
 			rotationParentId: issuePublicId,
@@ -196,6 +233,7 @@ describe("AdminKeyStore against workerd D1", () => {
 
 	it("changes limits atomically while preserving the key record", async () => {
 		const store = createAdminKeyStore(env.DB);
+		await store.issue(issue);
 		const change: AdminKeyLimitChange = {
 			key: { ...makeKey(issuePublicId), limits: { minute: 12, day: 240 } },
 			audit: makeAudit("key_limits_changed", issuePublicId),
@@ -217,6 +255,7 @@ describe("AdminKeyStore against workerd D1", () => {
 
 	it("rolls back an issue when key insertion fails", async () => {
 		const store = createAdminKeyStore(env.DB);
+		await store.issue(issue);
 		const duplicate: AdminKeyIssue = {
 			...issue,
 			key: { ...issuedKey, customerId: "customer-rolled-back" },
@@ -228,20 +267,5 @@ describe("AdminKeyStore against workerd D1", () => {
 			.bind("customer-rolled-back")
 			.first();
 		expect(customer).toBeNull();
-	});
-
-	it("removes retained keys and audits only after the retention timestamp", async () => {
-		const store = createAdminKeyStore(env.DB);
-
-		await store.purgeExpired(new Date("2027-11-08T00:00:00.000Z"));
-
-		const key = await env.DB.prepare("SELECT public_id FROM api_key_records WHERE public_id = ?1")
-			.bind(issuePublicId)
-			.first();
-		const audit = await env.DB.prepare("SELECT id FROM admin_audit_events WHERE public_id = ?1")
-			.bind(issuePublicId)
-			.first();
-		expect(key).toBeNull();
-		expect(audit).toBeNull();
 	});
 });

--- a/test/admin-worker.integration.test.ts
+++ b/test/admin-worker.integration.test.ts
@@ -1,0 +1,270 @@
+import { SELF, env } from "cloudflare:test";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import migrationOne from "../migrations/0001_api_key_records.sql?raw";
+import migrationTwo from "../migrations/0002_admin_key_lifecycle.sql?raw";
+import adminWorker, { type Env as AdminWorkerEnv } from "../src/admin/worker.js";
+
+const PRIVATE_JWK: JsonWebKey = {
+	alg: "RS256",
+	d: "GkwRKpsM_ctSV23gVU0w_J5-hnnpfDBorMgZtFrqoPEhsG0bSU8fNDkFrimIZfTpcPQhZ5AjEXMiPF33ojdCe5rXL-_tp-mvUe-g1VVTuLbyZiScsOpxf8B7_R8aFlYVykACvjiJWhVLPn_EyKfuIz-wRvYo0CIaGWZAbcNSDP00sw55wJpVGt-XqG8o59z8M8370kTCMoTeLHW_yo__WCZkfiQ2xn7TRl3ZcdL86KdMuWA8lHn9KRl4Z9DNN9Er4RRFMfh4QRX7EynPlVfLp14qVee7CkA0knDV6amyOCBy5lnV-Wayap5HXs4FMxZ4n6CZPiea6Hgx1fgaZfu6yQ",
+	e: "AQAB",
+	ext: true,
+	kty: "RSA",
+	n: "uREgDtm8lyX0HhR5NT-pLnwmBIxAqLr0jkEVAEc52UKVj4Ftrrk2umpbG1Et73Wnc4PBXpgQbXhwQVJYmucgh9YunefFKswlinOdxwSNFFjgyaOTBFVXFGkrWsKwf1aONvJn8iARqmL5Bo6D_afOftx71SCxbZYWchC8lNLXuNeftOYKyO2ka6gydMMMOTaViuZGk8dDOAA0mJbKwtdNseIHKLfhngsEZJ0OA4FTVUIyB2bH5D_DmuzAmZKwDovi-ErepLa4JHhihr_eeckFpzWR3sZSkipxaF26DMoHiBaz4zPLTdlMcebG5LVSyEMZFcCzbNKRT0GuyR7z-GQLGw",
+	p: "63uV9mmwSt6ol8RFiXl46OfCPGfrhqq_1eSliMcef-xIgUv0fLnPuB_z5zEtDOMtSaHz67cdPOPSkHNh542fwwQRY7y-Hs9gZeiT4eqkwb86d5js16EUOYIe7zX0zt60eSj5U1mo5FE8uJuQ-5MP0Y-oOSoewYyHTnxBbs6o88M",
+	q: "yTEFEJcKuKyNLTI_bdsjO-8vwr7byt3Lj1Za5QgAgAa7B3n49eUp3KPa31RKKo2e8ChI3tK-_sLn1xLtnFLy0C9g9jusZAOe7jIHkcGr5pLH4h9qsoNeIwtU7P7XbHwsATlZXz9ll04up1_2K9Ni7Wi68lfmvCUAcIrUTQo5Tck",
+	dp: "gq2ttfZG1_WiV76a3ESl3ZInj0AYSz5cgQWG-1WMzm7Aecg94C15YXOR9d2rY3h6vF78rvWKayz-wBzX2xkT7LRINjIay5xHoaYk0v1U-xP1DUO3Q55nS9ay9graVSbvvkEHw8KA4FtYuBXUqledMq1nLHn8YWpr-BkqcqSKy-M",
+	dq: "i7eHFOZPg8AQqnpioh-0cELCoDN63373hisqJDNSZZZG_AIwalMipx8DOGSIvNRss8rGEDe6e6FO74UtjYntJbZBV75JEYuSK0iDCS29-vmj5dx7dEzWau_Lomm3oJb62D7DWenk2xZoP8PcaML7yHMaoIF6st3fWEiQ9o9LDEE",
+	qi: "bQNwC3gyZnwj7vpnn77cqgj1F-54DDDcI3LUX1-8mMQ9cpQH353dACMO_2U2bspK-hY27a0PvnATs5t1WzifPZNsjcr9sIuDmQrK6hbsWOLI50iT6_RMDCpgFSHcIYRS_VGr6LlmFmtylbYd4Z6L_pnXoZtuwT7dzhbDleGwIYY",
+	key_ops: ["sign"],
+};
+const PUBLIC_JWK = {
+	alg: "RS256",
+	e: "AQAB",
+	ext: true,
+	kid: "access-test-key",
+	kty: "RSA",
+	n: "uREgDtm8lyX0HhR5NT-pLnwmBIxAqLr0jkEVAEc52UKVj4Ftrrk2umpbG1Et73Wnc4PBXpgQbXhwQVJYmucgh9YunefFKswlinOdxwSNFFjgyaOTBFVXFGkrWsKwf1aONvJn8iARqmL5Bo6D_afOftx71SCxbZYWchC8lNLXuNeftOYKyO2ka6gydMMMOTaViuZGk8dDOAA0mJbKwtdNseIHKLfhngsEZJ0OA4FTVUIyB2bH5D_DmuzAmZKwDovi-ErepLa4JHhihr_eeckFpzWR3sZSkipxaF26DMoHiBaz4zPLTdlMcebG5LVSyEMZFcCzbNKRT0GuyR7z-GQLGw",
+	key_ops: ["verify"],
+} satisfies JsonWebKey & { readonly kid: string };
+
+type CredentialResponse = {
+	readonly credential: string;
+	readonly key: { readonly publicId: string; readonly status: string };
+};
+
+beforeEach(async () => {
+	await env.DB.prepare("DROP TABLE IF EXISTS admin_audit_events").run();
+	await env.DB.prepare("DROP TABLE IF EXISTS api_key_records").run();
+	await env.DB.prepare("DROP TABLE IF EXISTS customers").run();
+	await applyMigration(migrationOne);
+	await applyMigration(migrationTwo);
+	vi.stubGlobal("fetch", async () => Response.json({ keys: [PUBLIC_JWK] }));
+});
+
+describe("Access-protected admin Worker", () => {
+	it("issues an operator-issued key once with credential-safe response headers and no plaintext persistence", async () => {
+		// Given: a signed Access assertion for the allowlisted human operator.
+		const request = await operatorRequest("/v1/keys", { customerId: "customer-issue" });
+
+		// When: the operator issues a key through the separate admin Worker.
+		const response = await SELF.fetch(request);
+
+		// Then: only this no-store response reveals the plaintext, while D1 contains only its HMAC.
+		expect(response.status).toBe(201);
+		expect(response.headers.get("cache-control")).toBe("no-store");
+		expect(response.headers.get("pragma")).toBe("no-cache");
+		expect(response.headers.get("referrer-policy")).toBe("no-referrer");
+		expect(response.headers.get("x-content-type-options")).toBe("nosniff");
+		expect(response.headers.get("access-control-allow-origin")).toBeNull();
+		const body = (await response.json()) as CredentialResponse;
+		expect(body.credential).toMatch(/^lc_test_[A-Za-z0-9-]+_[A-Za-z0-9_-]{43}$/u);
+		const stored = await env.DB.prepare(
+			"SELECT hmac_sha256_hex FROM api_key_records WHERE public_id = ?1",
+		)
+			.bind(body.key.publicId)
+			.first<{ readonly hmac_sha256_hex: string }>();
+		expect(stored?.hmac_sha256_hex).not.toContain(body.credential);
+		expect(JSON.stringify(stored)).not.toContain("lc_test_");
+	});
+
+	it.each([
+		{ label: "empty", pepper: "" },
+		{ label: "missing", pepper: undefined },
+	])("fails closed before D1 mutation when the API key pepper is $label", async ({ pepper }) => {
+		// Given: a real workerd D1 binding and an otherwise-valid verified Access request.
+		const request = await operatorRequest("/v1/keys", { customerId: "customer-no-pepper" });
+
+		// When: key issuance runs without its required HMAC pepper.
+		const response = await adminWorker.fetch(request, environmentWithPepper(pepper));
+
+		// Then: it returns a generic failure and does not create a credential record.
+		expect(response.status).toBe(500);
+		const count = await env.DB.prepare("SELECT COUNT(*) AS count FROM api_key_records").first<{
+			readonly count: number;
+		}>();
+		expect(count?.count).toBe(0);
+	});
+
+	it("rotates, changes limits, and revokes through operator-only routes", async () => {
+		// Given: an existing operator-issued key.
+		const issued = await issueKey("customer-lifecycle");
+
+		// When: the operator rotates it, changes the replacement limits, and revokes that replacement.
+		const rotatedResponse = await SELF.fetch(
+			await operatorRequest(`/v1/keys/${issued.key.publicId}/rotate`),
+		);
+		const rotated = (await rotatedResponse.json()) as CredentialResponse;
+		const limitResponse = await SELF.fetch(
+			await operatorRequest(
+				`/v1/keys/${rotated.key.publicId}/limits`,
+				{ day: 3_000, minute: 90 },
+				"PUT",
+			),
+		);
+		const revokeResponse = await SELF.fetch(
+			await operatorRequest(`/v1/keys/${rotated.key.publicId}/revoke`),
+		);
+
+		// Then: lifecycle state changed without exposing another credential from the non-credential routes.
+		expect(rotatedResponse.status).toBe(201);
+		expect(rotatedResponse.headers.get("cache-control")).toBe("no-store");
+		expect(limitResponse.status).toBe(200);
+		expect(await limitResponse.text()).not.toContain(rotated.credential);
+		expect(revokeResponse.status).toBe(200);
+		const replacement = await env.DB.prepare(
+			"SELECT status, minute_limit, day_limit, revoked_at FROM api_key_records WHERE public_id = ?1",
+		)
+			.bind(rotated.key.publicId)
+			.first<{
+				readonly day_limit: number;
+				readonly minute_limit: number;
+				readonly revoked_at: string | null;
+				readonly status: string;
+			}>();
+		expect(replacement).toMatchObject({ day_limit: 3_000, minute_limit: 90, status: "revoked" });
+		expect(replacement?.revoked_at).not.toBeNull();
+	});
+
+	it.each([
+		["missing assertion", undefined],
+		["wrong issuer", { iss: "https://other.example.invalid" }],
+		["wrong audience", { aud: "other-audience" }],
+		["expired assertion", { exp: Math.floor(Date.now() / 1_000) - 1 }],
+		["not-yet-valid assertion", { nbf: Math.floor(Date.now() / 1_000) + 60 }],
+		["service-token subject", { sub: "" }],
+		["unallowlisted subject", { sub: "another-operator" }],
+	])("rejects %s before administrative handling", async (_name, claims) => {
+		// Given: a request without a valid verified Access identity, including a spoofable email header.
+		const request =
+			claims === undefined
+				? new Request("https://admin.lexcerta.ai/v1/keys", {
+						method: "POST",
+						headers: { "cf-access-authenticated-user-email": "operator@example.invalid" },
+						body: JSON.stringify({ customerId: "customer-rejected" }),
+					})
+				: await operatorRequest("/v1/keys", { customerId: "customer-rejected" }, "POST", claims);
+
+		// When: it reaches the admin Worker.
+		const response = await SELF.fetch(request);
+
+		// Then: it receives the generic Access rejection and no key record is created.
+		expect(response.status).toBe(401);
+		expect(await response.text()).toBe('{"error":"Unauthorized"}');
+		const count = await env.DB.prepare("SELECT COUNT(*) AS count FROM api_key_records").first<{
+			readonly count: number;
+		}>();
+		expect(count?.count).toBe(0);
+	});
+
+	it("rejects an assertion with an invalid signature", async () => {
+		// Given: a syntactically valid signed assertion whose signature is altered after signing.
+		const valid = await signedAccessJwt();
+		const tampered = tamperSignature(valid);
+
+		// When: it requests key issuance.
+		const response = await SELF.fetch(
+			new Request("https://admin.lexcerta.ai/v1/keys", {
+				method: "POST",
+				headers: { "cf-access-jwt-assertion": tampered, "content-type": "application/json" },
+				body: JSON.stringify({ customerId: "customer-tampered" }),
+			}),
+		);
+
+		// Then: signature verification prevents the spoofed identity from reaching persistence.
+		expect(response.status).toBe(401);
+		const count = await env.DB.prepare("SELECT COUNT(*) AS count FROM api_key_records").first<{
+			readonly count: number;
+		}>();
+		expect(count?.count).toBe(0);
+	});
+});
+
+async function issueKey(customerId: string): Promise<CredentialResponse> {
+	const response = await SELF.fetch(await operatorRequest("/v1/keys", { customerId }));
+	expect(response.status).toBe(201);
+	return (await response.json()) as CredentialResponse;
+}
+
+async function operatorRequest(
+	path: string,
+	body?: object,
+	method = "POST",
+	claims: Readonly<Record<string, string | number>> = {},
+): Promise<Request> {
+	const headers = new Headers({ "cf-access-jwt-assertion": await signedAccessJwt(claims) });
+	if (body !== undefined) headers.set("content-type", "application/json");
+	return new Request(`https://admin.lexcerta.ai${path}`, {
+		method,
+		headers,
+		...(body === undefined ? {} : { body: JSON.stringify(body) }),
+	});
+}
+
+async function signedAccessJwt(
+	claims: Readonly<Record<string, string | number>> = {},
+): Promise<string> {
+	const now = Math.floor(Date.now() / 1_000);
+	const header = base64Url(JSON.stringify({ alg: "RS256", kid: "access-test-key", typ: "JWT" }));
+	const payload = base64Url(
+		JSON.stringify({
+			aud: "admin-audience-test",
+			exp: now + 300,
+			iss: "https://access-test.example.invalid",
+			sub: "operator-subject-test",
+			...claims,
+		}),
+	);
+	const key = await crypto.subtle.importKey(
+		"jwk",
+		PRIVATE_JWK,
+		{ name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
+		false,
+		["sign"],
+	);
+	const signature = await crypto.subtle.sign(
+		"RSASSA-PKCS1-v1_5",
+		key,
+		new TextEncoder().encode(`${header}.${payload}`),
+	);
+	return `${header}.${payload}.${base64Url(signature)}`;
+}
+
+async function applyMigration(sql: string): Promise<void> {
+	for (const statement of sql
+		.split(";")
+		.map((value) => value.trim())
+		.filter(Boolean)) {
+		await env.DB.prepare(statement).run();
+	}
+}
+
+function base64Url(value: string | ArrayBuffer): string {
+	const bytes = typeof value === "string" ? new TextEncoder().encode(value) : new Uint8Array(value);
+	return btoa(Array.from(bytes, (byte) => String.fromCharCode(byte)).join(""))
+		.replaceAll("+", "-")
+		.replaceAll("/", "_")
+		.replace(/=+$/u, "");
+}
+
+function tamperSignature(assertion: string): string {
+	const segments = assertion.split(".");
+	const signature = segments[2];
+	if (segments.length !== 3 || signature === undefined || signature.length < 2) {
+		throw new Error("Expected a JWT with a non-empty signature");
+	}
+	const changedFirstCharacter = signature.startsWith("A") ? "B" : "A";
+	return `${segments[0]}.${segments[1]}.${changedFirstCharacter}${signature.slice(1)}`;
+}
+
+function environmentWithPepper(pepper: string | undefined): AdminWorkerEnv {
+	return {
+		ACCESS_AUDIENCE: "admin-audience-test",
+		ACCESS_ISSUER: "https://access-test.example.invalid",
+		ACCESS_JWKS_URL: "https://access-test.example.invalid/cdn-cgi/access/certs",
+		ACCESS_OPERATOR_SUBJECT: "operator-subject-test",
+		DB: env.DB,
+		KEY_ENVIRONMENT: env.KEY_ENVIRONMENT,
+		...(pepper === undefined ? {} : { API_KEY_PEPPER: pepper }),
+	};
+}

--- a/test/admin-worker.integration.test.ts
+++ b/test/admin-worker.integration.test.ts
@@ -21,7 +21,6 @@ const PRIVATE_JWK: JsonWebKey = {
 const PUBLIC_JWK = {
 	alg: "RS256",
 	e: "AQAB",
-	ext: true,
 	kid: "access-test-key",
 	kty: "RSA",
 	n: "uREgDtm8lyX0HhR5NT-pLnwmBIxAqLr0jkEVAEc52UKVj4Ftrrk2umpbG1Et73Wnc4PBXpgQbXhwQVJYmucgh9YunefFKswlinOdxwSNFFjgyaOTBFVXFGkrWsKwf1aONvJn8iARqmL5Bo6D_afOftx71SCxbZYWchC8lNLXuNeftOYKyO2ka6gydMMMOTaViuZGk8dDOAA0mJbKwtdNseIHKLfhngsEZJ0OA4FTVUIyB2bH5D_DmuzAmZKwDovi-ErepLa4JHhihr_eeckFpzWR3sZSkipxaF26DMoHiBaz4zPLTdlMcebG5LVSyEMZFcCzbNKRT0GuyR7z-GQLGw",
@@ -124,6 +123,33 @@ describe("Access-protected admin Worker", () => {
 			}>();
 		expect(replacement).toMatchObject({ day_limit: 3_000, minute_limit: 90, status: "revoked" });
 		expect(replacement?.revoked_at).not.toBeNull();
+	});
+
+	it("permits one concurrent rotation and rejects the CAS loser without a child or audit", async () => {
+		// Given: one active operator-issued key and two independently authenticated rotation requests.
+		const issued = await issueKey("customer-rotation-race");
+		const [firstRequest, secondRequest] = await Promise.all([
+			operatorRequest(`/v1/keys/${issued.key.publicId}/rotate`),
+			operatorRequest(`/v1/keys/${issued.key.publicId}/rotate`),
+		]);
+
+		// When: both rotations reach the real workerd D1 surface concurrently.
+		const responses = await Promise.all([SELF.fetch(firstRequest), SELF.fetch(secondRequest)]);
+
+		// Then: compare-and-swap creates exactly one replacement and one sanitized rotation audit.
+		expect(responses.map((response) => response.status).sort()).toEqual([201, 409]);
+		const children = await env.DB.prepare(
+			"SELECT COUNT(*) AS count FROM api_key_records WHERE rotation_parent_id = ?1",
+		)
+			.bind(issued.key.publicId)
+			.first<{ readonly count: number }>();
+		const audits = await env.DB.prepare(
+			"SELECT COUNT(*) AS count FROM admin_audit_events WHERE action = 'key_rotated' AND customer_id = ?1",
+		)
+			.bind("customer-rotation-race")
+			.first<{ readonly count: number }>();
+		expect(children?.count).toBe(1);
+		expect(audits?.count).toBe(1);
 	});
 
 	it.each([

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,7 @@
 	},
 	"include": [
 		"src/worker.ts",
+		"src/admin/**/*.ts",
 		"src/auth/**/*.ts",
 		"src/verification/**/*.ts",
 		"worker-configuration.d.ts"

--- a/vitest.admin.config.ts
+++ b/vitest.admin.config.ts
@@ -1,0 +1,12 @@
+import { cloudflareTest } from "@cloudflare/vitest-pool-workers";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+	plugins: [
+		cloudflareTest({
+			wrangler: { configPath: "./wrangler.admin.jsonc", environment: "test" },
+			miniflare: { bindings: { API_KEY_PEPPER: "admin-test-pepper" } },
+		}),
+	],
+	test: { include: ["src/admin/**/*.test.ts", "test/admin-*.test.ts"] },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,5 +10,6 @@ export default defineConfig({
 	],
 	test: {
 		include: ["src/auth/**/*.test.ts", "src/verification/**/*.test.ts", "test/**/*.test.ts"],
+		exclude: ["test/admin-*.test.ts"],
 	},
 });

--- a/wrangler.admin.jsonc
+++ b/wrangler.admin.jsonc
@@ -4,6 +4,11 @@
 	"main": "src/admin/worker.ts",
 	"compatibility_date": "2026-08-01",
 	"workers_dev": false,
+	// Provision ACCESS_AUDIENCE, ACCESS_ISSUER, ACCESS_JWKS_URL, ACCESS_OPERATOR_SUBJECT, and API_KEY_PEPPER for production outside this file.
+	// Missing Access bindings fail closed with 401; a missing pepper fails closed with 500 before D1 mutation.
+	"vars": {
+		"KEY_ENVIRONMENT": "production"
+	},
 	"routes": [{ "pattern": "admin.lexcerta.ai", "custom_domain": true }],
 	"d1_databases": [
 		{

--- a/wrangler.admin.jsonc
+++ b/wrangler.admin.jsonc
@@ -1,0 +1,39 @@
+{
+	"$schema": "./node_modules/wrangler/config-schema.json",
+	"name": "lexcerta-admin",
+	"main": "src/admin/worker.ts",
+	"compatibility_date": "2026-08-01",
+	"workers_dev": false,
+	"routes": [{ "pattern": "admin.lexcerta.ai", "custom_domain": true }],
+	"d1_databases": [
+		{
+			"binding": "DB",
+			"database_name": "lexcerta-production",
+			"database_id": "00000000-0000-0000-0000-000000000001",
+			"migrations_dir": "migrations"
+		}
+	],
+	"observability": { "enabled": true },
+	"env": {
+		"test": {
+			"name": "lexcerta-admin-test",
+			"workers_dev": true,
+			"routes": [],
+			"d1_databases": [
+				{
+					"binding": "DB",
+					"database_name": "lexcerta-test",
+					"database_id": "00000000-0000-0000-0000-000000000002",
+					"migrations_dir": "migrations"
+				}
+			],
+			"vars": {
+				"ACCESS_AUDIENCE": "admin-audience-test",
+				"ACCESS_ISSUER": "https://access-test.example.invalid",
+				"ACCESS_JWKS_URL": "https://access-test.example.invalid/cdn-cgi/access/certs",
+				"ACCESS_OPERATOR_SUBJECT": "operator-subject-test",
+				"KEY_ENVIRONMENT": "test"
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #3

## Outcome
- add a separate Cloudflare Access-verified admin Worker for issue, rotate, revoke, and per-key limit changes
- generate environment-scoped 32-byte credentials, persist only complete-token HMACs, and return plaintext once with no-store protections
- serialize rotation with D1 compare-and-swap and record sanitized lifecycle audits
- keep production/test admin key environments explicit and isolated

## Verification
- `npm run check` (108 core + 32 admin tests)
- production and test admin Wrangler dry-runs
- five independent exact-SHA review lanes PASS at `3c09494adbade9e6203dcb82d975425ba496d04e`
- hands-on workerd HTTP/D1 QA: 14/14 scenarios

## Deferred by dependency
- scheduled retention deletion: #9
- staging and production resource/Access provisioning: #11 and #12