### PR TITLE
Add durable citation source caching

### DIFF
--- a/migrations/0004_citation_source_cache.sql
+++ b/migrations/0004_citation_source_cache.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS citation_source_states (
+	normalized_citation TEXT PRIMARY KEY NOT NULL CHECK (length(normalized_citation) BETWEEN 1 AND 256),
+	state_json TEXT NOT NULL CHECK (length(state_json) BETWEEN 1 AND 4096 AND json_valid(state_json)),
+	updated_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS citation_fetch_leases (
+	normalized_citation TEXT PRIMARY KEY NOT NULL CHECK (length(normalized_citation) BETWEEN 1 AND 256),
+	owner_token TEXT NOT NULL CHECK (length(owner_token) BETWEEN 1 AND 256),
+	expires_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS citation_fetch_leases_expiry_idx
+	ON citation_fetch_leases(expires_at);

--- a/package.json
+++ b/package.json
@@ -12,9 +12,9 @@
 		"types": "wrangler types worker-configuration.d.ts",
 		"types:check": "wrangler types worker-configuration.d.ts --check",
 		"typecheck": "npm run types:check && tsc --noEmit && tsc --project test/tsconfig.json --noEmit",
-		"lint": "biome lint src/admin src/admission src/courtlistener src/worker.ts src/mcp.ts src/auth src/verification test vitest.config.ts vitest.admin.config.ts",
+		"lint": "biome lint src/admin src/admission src/courtlistener src/cache src/worker.ts src/mcp.ts src/auth src/verification test vitest.config.ts vitest.admin.config.ts",
 		"format": "biome format --write package.json tsconfig.json test/tsconfig.json vitest.config.ts vitest.admin.config.ts wrangler.jsonc wrangler.admin.jsonc src/admin src/admission src/courtlistener src/worker.ts src/mcp.ts src/auth src/verification test",
-		"format:check": "biome format package.json tsconfig.json test/tsconfig.json vitest.config.ts vitest.admin.config.ts wrangler.jsonc wrangler.admin.jsonc src/admin src/admission src/courtlistener src/worker.ts src/mcp.ts src/auth src/verification test",
+		"format:check": "biome format package.json tsconfig.json test/tsconfig.json vitest.config.ts vitest.admin.config.ts wrangler.jsonc wrangler.admin.jsonc src/admin src/admission src/courtlistener src/cache src/worker.ts src/mcp.ts src/auth src/verification test",
 		"check": "npm run format:check && npm run lint && npm run typecheck && npm run test"
 	},
 	"dependencies": {

--- a/src/cache/citation-observation-store.ts
+++ b/src/cache/citation-observation-store.ts
@@ -1,0 +1,44 @@
+import type {
+	CitationSourceCacheState,
+	CitationSourceObservation,
+} from "../verification/citation-source-cache.js";
+
+export const CITATION_FETCH_LEASE_MS = 10_000;
+
+export type StoredCitationObservation = Exclude<
+	CitationSourceCacheState,
+	{ readonly kind: "empty" }
+>;
+
+export type LeaseAcquireResult =
+	| { readonly kind: "acquired"; readonly expiresAt: string }
+	| { readonly kind: "held"; readonly expiresAt: string };
+
+export type LeaseFillResult =
+	| { readonly kind: "stored"; readonly observation: StoredCitationObservation }
+	| { readonly kind: "lease_unavailable" };
+
+export type LeaseReleaseResult =
+	| { readonly kind: "released" }
+	| { readonly kind: "lease_unavailable" };
+
+export type CitationObservationStore = {
+	readonly read: (input: {
+		readonly normalizedCitation: string;
+	}) => Promise<StoredCitationObservation | null>;
+	readonly acquireLease: (input: {
+		readonly normalizedCitation: string;
+		readonly ownerToken: string;
+		readonly now: Date;
+	}) => Promise<LeaseAcquireResult>;
+	readonly fillLease: (input: {
+		readonly normalizedCitation: string;
+		readonly ownerToken: string;
+		readonly now: Date;
+		readonly observation: CitationSourceObservation;
+	}) => Promise<LeaseFillResult>;
+	readonly releaseLease: (input: {
+		readonly normalizedCitation: string;
+		readonly ownerToken: string;
+	}) => Promise<LeaseReleaseResult>;
+};

--- a/src/cache/citation-observation-store.ts
+++ b/src/cache/citation-observation-store.ts
@@ -18,6 +18,11 @@ export type LeaseFillResult =
 	| { readonly kind: "stored"; readonly observation: StoredCitationObservation }
 	| { readonly kind: "lease_unavailable" };
 
+export type LeasePurgeResult =
+	| { readonly kind: "purged"; readonly observation: StoredCitationObservation | null }
+	| { readonly kind: "state_changed" }
+	| { readonly kind: "lease_unavailable" };
+
 export type LeaseReleaseResult =
 	| { readonly kind: "released" }
 	| { readonly kind: "lease_unavailable" };
@@ -37,6 +42,12 @@ export type CitationObservationStore = {
 		readonly now: Date;
 		readonly observation: CitationSourceObservation;
 	}) => Promise<LeaseFillResult>;
+	readonly purgeExpiredNegativeLease: (input: {
+		readonly normalizedCitation: string;
+		readonly ownerToken: string;
+		readonly now: Date;
+		readonly expected: Extract<StoredCitationObservation, { readonly kind: "negative" }>;
+	}) => Promise<LeasePurgeResult>;
 	readonly releaseLease: (input: {
 		readonly normalizedCitation: string;
 		readonly ownerToken: string;

--- a/src/cache/d1-citation-observation-store.ts
+++ b/src/cache/d1-citation-observation-store.ts
@@ -1,0 +1,193 @@
+import { z } from "zod";
+import {
+	initialCitationSourceCacheState,
+	recordCitationSourceObservation,
+} from "../verification/citation-source-cache.js";
+import type {
+	CitationSourceCacheState,
+	CitationSourceObservation,
+} from "../verification/citation-source-cache.js";
+import { CITATION_FETCH_LEASE_MS } from "./citation-observation-store.js";
+import type {
+	CitationObservationStore,
+	LeaseAcquireResult,
+	LeaseFillResult,
+	LeaseReleaseResult,
+	StoredCitationObservation,
+} from "./citation-observation-store.js";
+
+const canonicalUrlSchema = z.string().url().max(2_048).refine(isCourtListenerCanonicalUrl);
+const storedStateSchema = z.discriminatedUnion("kind", [
+	z.object({
+		kind: z.literal("positive"),
+		positive: positiveSchema(),
+	}),
+	z.object({
+		kind: z.literal("negative"),
+		negative: negativeSchema(),
+		superseded: positiveSchema().nullable(),
+	}),
+	z.object({
+		kind: z.literal("reversal_pending"),
+		superseded: positiveSchema(),
+		firstNegative: negativeSchema(),
+	}),
+]);
+
+const stateRowSchema = z.object({ state_json: z.string().min(1).max(4_096) });
+const leaseRowSchema = z.object({ expires_at: z.string().datetime({ offset: true }) });
+
+export function createD1CitationObservationStore(database: D1Database): CitationObservationStore {
+	return {
+		read: async ({ normalizedCitation }) => readState(database, normalizedCitation),
+		acquireLease: async (input) => acquireLease(database, input),
+		fillLease: async (input) => fillLease(database, input),
+		releaseLease: async ({ normalizedCitation, ownerToken }) => {
+			const result = await database
+				.prepare(
+					"DELETE FROM citation_fetch_leases WHERE normalized_citation = ?1 AND owner_token = ?2",
+				)
+				.bind(normalizedCitation, ownerToken)
+				.run();
+			return changes(result) === 1 ? { kind: "released" } : { kind: "lease_unavailable" };
+		},
+	};
+}
+
+async function acquireLease(
+	database: D1Database,
+	input: { readonly normalizedCitation: string; readonly ownerToken: string; readonly now: Date },
+): Promise<LeaseAcquireResult> {
+	const now = input.now.toISOString();
+	const expiresAt = new Date(input.now.getTime() + CITATION_FETCH_LEASE_MS).toISOString();
+	const result = await database
+		.prepare(
+			"INSERT INTO citation_fetch_leases (normalized_citation, owner_token, expires_at) VALUES (?1, ?2, ?3) ON CONFLICT(normalized_citation) DO UPDATE SET owner_token = excluded.owner_token, expires_at = excluded.expires_at WHERE citation_fetch_leases.expires_at <= ?4",
+		)
+		.bind(input.normalizedCitation, input.ownerToken, expiresAt, now)
+		.run();
+	if (changes(result) === 1) return { kind: "acquired", expiresAt };
+	const held = await database
+		.prepare("SELECT expires_at FROM citation_fetch_leases WHERE normalized_citation = ?1")
+		.bind(input.normalizedCitation)
+		.first<unknown>();
+	if (held === null) return acquireLease(database, input);
+	const parsed = leaseRowSchema.safeParse(held);
+	if (!parsed.success) throw new CitationSourceStateCorruptError();
+	return { kind: "held", expiresAt: parsed.data.expires_at };
+}
+
+async function fillLease(
+	database: D1Database,
+	input: {
+		readonly normalizedCitation: string;
+		readonly ownerToken: string;
+		readonly now: Date;
+		readonly observation: CitationSourceObservation;
+	},
+): Promise<LeaseFillResult> {
+	const current =
+		(await readState(database, input.normalizedCitation)) ?? initialCitationSourceCacheState();
+	const state = recordCitationSourceObservation({
+		state: current,
+		observation: input.observation,
+		now: input.now,
+	});
+	const now = input.now.toISOString();
+	const saved = JSON.stringify(state);
+	const results = await database.batch([
+		database
+			.prepare(
+				"INSERT INTO citation_source_states (normalized_citation, state_json, updated_at) SELECT ?1, ?2, ?3 WHERE EXISTS (SELECT 1 FROM citation_fetch_leases WHERE normalized_citation = ?1 AND owner_token = ?4 AND expires_at > ?3) ON CONFLICT(normalized_citation) DO UPDATE SET state_json = excluded.state_json, updated_at = excluded.updated_at WHERE EXISTS (SELECT 1 FROM citation_fetch_leases WHERE normalized_citation = ?1 AND owner_token = ?4 AND expires_at > ?3)",
+			)
+			.bind(input.normalizedCitation, saved, now, input.ownerToken),
+		database
+			.prepare(
+				"DELETE FROM citation_fetch_leases WHERE normalized_citation = ?1 AND owner_token = ?2 AND expires_at > ?3",
+			)
+			.bind(input.normalizedCitation, input.ownerToken, now),
+	]);
+	return changes(results[0]) === 1
+		? { kind: "stored", observation: requireStoredState(state) }
+		: { kind: "lease_unavailable" };
+}
+
+async function readState(
+	database: D1Database,
+	normalizedCitation: string,
+): Promise<StoredCitationObservation | null> {
+	const row = await database
+		.prepare("SELECT state_json FROM citation_source_states WHERE normalized_citation = ?1")
+		.bind(normalizedCitation)
+		.first<unknown>();
+	if (row === null) return null;
+	const parsedRow = stateRowSchema.safeParse(row);
+	if (!parsedRow.success) throw new CitationSourceStateCorruptError();
+	const value = jsonValue(parsedRow.data.state_json);
+	const state = storedStateSchema.safeParse(value);
+	if (!state.success) throw new CitationSourceStateCorruptError();
+	return state.data;
+}
+
+function positiveSchema() {
+	return z.object({
+		kind: z.literal("positive"),
+		cluster: z.object({
+			id: z.number().int().positive(),
+			canonicalUrl: canonicalUrlSchema,
+		}),
+		retrievedAt: z
+			.string()
+			.datetime({ offset: true })
+			.transform((value) => new Date(value)),
+	});
+}
+
+function negativeSchema() {
+	return z.object({
+		kind: z.literal("negative"),
+		retrievedAt: z
+			.string()
+			.datetime({ offset: true })
+			.transform((value) => new Date(value)),
+	});
+}
+
+function jsonValue(value: string): unknown {
+	try {
+		return JSON.parse(value);
+	} catch (error) {
+		if (error instanceof SyntaxError) throw new CitationSourceStateCorruptError();
+		throw error;
+	}
+}
+
+function requireStoredState(state: CitationSourceCacheState): StoredCitationObservation {
+	if (state.kind === "empty") throw new CitationSourceStateCorruptError();
+	return state;
+}
+
+function isCourtListenerCanonicalUrl(value: string): boolean {
+	try {
+		const url = new URL(value);
+		return (
+			url.protocol === "https:" &&
+			(url.hostname === "courtlistener.com" || url.hostname === "www.courtlistener.com")
+		);
+	} catch {
+		return false;
+	}
+}
+
+function changes(result: D1Result<unknown> | undefined): number {
+	const value = result?.meta.changes;
+	return typeof value === "number" ? value : 0;
+}
+
+export class CitationSourceStateCorruptError extends Error {
+	readonly name = "CitationSourceStateCorruptError";
+
+	constructor() {
+		super("citation source cache state is corrupt");
+	}
+}

--- a/src/cache/d1-citation-observation-store.ts
+++ b/src/cache/d1-citation-observation-store.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import {
 	initialCitationSourceCacheState,
+	purgeExpiredCitationNegative,
 	recordCitationSourceObservation,
 } from "../verification/citation-source-cache.js";
 import type {
@@ -12,6 +13,7 @@ import type {
 	CitationObservationStore,
 	LeaseAcquireResult,
 	LeaseFillResult,
+	LeasePurgeResult,
 	LeaseReleaseResult,
 	StoredCitationObservation,
 } from "./citation-observation-store.js";
@@ -42,6 +44,7 @@ export function createD1CitationObservationStore(database: D1Database): Citation
 		read: async ({ normalizedCitation }) => readState(database, normalizedCitation),
 		acquireLease: async (input) => acquireLease(database, input),
 		fillLease: async (input) => fillLease(database, input),
+		purgeExpiredNegativeLease: async (input) => purgeExpiredNegativeLease(database, input),
 		releaseLease: async ({ normalizedCitation, ownerToken }) => {
 			const result = await database
 				.prepare(
@@ -52,6 +55,39 @@ export function createD1CitationObservationStore(database: D1Database): Citation
 			return changes(result) === 1 ? { kind: "released" } : { kind: "lease_unavailable" };
 		},
 	};
+}
+
+async function purgeExpiredNegativeLease(
+	database: D1Database,
+	input: {
+		readonly normalizedCitation: string;
+		readonly ownerToken: string;
+		readonly now: Date;
+		readonly expected: Extract<StoredCitationObservation, { readonly kind: "negative" }>;
+	},
+): Promise<LeasePurgeResult> {
+	const next = purgeExpiredCitationNegative({ state: input.expected, now: input.now });
+	const expected = JSON.stringify(input.expected);
+	const now = input.now.toISOString();
+	const result =
+		next.kind === "empty"
+			? await database
+					.prepare(
+						"DELETE FROM citation_source_states WHERE normalized_citation = ?1 AND state_json = ?2 AND EXISTS (SELECT 1 FROM citation_fetch_leases WHERE normalized_citation = ?1 AND owner_token = ?3 AND expires_at > ?4)",
+					)
+					.bind(input.normalizedCitation, expected, input.ownerToken, now)
+					.run()
+			: await database
+					.prepare(
+						"UPDATE citation_source_states SET state_json = ?1, updated_at = ?2 WHERE normalized_citation = ?3 AND state_json = ?4 AND EXISTS (SELECT 1 FROM citation_fetch_leases WHERE normalized_citation = ?3 AND owner_token = ?5 AND expires_at > ?2)",
+					)
+					.bind(JSON.stringify(next), now, input.normalizedCitation, expected, input.ownerToken)
+					.run();
+	if (changes(result) === 1)
+		return { kind: "purged", observation: next.kind === "empty" ? null : next };
+	return (await ownsActiveLease(database, input.normalizedCitation, input.ownerToken, now))
+		? { kind: "state_changed" }
+		: { kind: "lease_unavailable" };
 }
 
 async function acquireLease(
@@ -127,6 +163,21 @@ async function readState(
 	const state = storedStateSchema.safeParse(value);
 	if (!state.success) throw new CitationSourceStateCorruptError();
 	return state.data;
+}
+
+async function ownsActiveLease(
+	database: D1Database,
+	normalizedCitation: string,
+	ownerToken: string,
+	now: string,
+): Promise<boolean> {
+	const lease = await database
+		.prepare(
+			"SELECT 1 FROM citation_fetch_leases WHERE normalized_citation = ?1 AND owner_token = ?2 AND expires_at > ?3",
+		)
+		.bind(normalizedCitation, ownerToken, now)
+		.first<unknown>();
+	return lease !== null;
 }
 
 function positiveSchema() {

--- a/src/courtlistener/api-binding.test.ts
+++ b/src/courtlistener/api-binding.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import { type CourtListenerTransport, createCourtListenerApi } from "./api.js";
+
+const CITATION = { normalized: "347 U.S. 483" };
+
+function givenTransport(response: Response) {
+	const requests: Request[] = [];
+	const transport: CourtListenerTransport = async (request) => {
+		requests.push(request);
+		return response;
+	};
+	return { transport, requests };
+}
+
+function conclusiveResponse(status: 200 | 404, normalizedCitations: readonly string[]): Response {
+	return Response.json([
+		{
+			status,
+			normalized_citations: normalizedCitations,
+			clusters:
+				status === 200
+					? [{ id: 123, absolute_url: "/opinion/123/brown-v-board-of-education/" }]
+					: [],
+		},
+	]);
+}
+
+describe("CourtListener conclusive response binding", () => {
+	it.each([
+		[200, ["1 U.S. 200"]],
+		[404, ["1 U.S. 200"]],
+	] as const)(
+		"rejects mismatched conclusive status %i without retrying",
+		async (status, normalized) => {
+			// Given: CourtListener returns a conclusive item for a different canonical citation.
+			const given = givenTransport(conclusiveResponse(status, normalized));
+
+			// When: the adapter looks up the requested citation.
+			const result = await createCourtListenerApi({
+				token: "token",
+				transport: given.transport,
+			}).lookupCitation(CITATION);
+
+			// Then: the unbound item is malformed and the adapter made one attempt.
+			expect(result).toEqual({ kind: "malformed_response" });
+			expect(given.requests).toHaveLength(1);
+		},
+	);
+
+	it.each([
+		[200, []],
+		[200, [CITATION.normalized, "1 U.S. 200"]],
+		[404, []],
+		[404, [CITATION.normalized, "1 U.S. 200"]],
+	] as const)(
+		"rejects conclusive status %i with non-singleton normalization %j",
+		async (status, normalized) => {
+			// Given: CourtListener returns a conclusive item with empty or multiple normalized citations.
+			const given = givenTransport(conclusiveResponse(status, normalized));
+
+			// When: the adapter looks up one requested normalized citation.
+			const result = await createCourtListenerApi({
+				token: "token",
+				transport: given.transport,
+			}).lookupCitation(CITATION);
+
+			// Then: the ambiguous source binding is malformed and never retried.
+			expect(result).toEqual({ kind: "malformed_response" });
+			expect(given.requests).toHaveLength(1);
+		},
+	);
+});

--- a/src/courtlistener/api.test.ts
+++ b/src/courtlistener/api.test.ts
@@ -68,9 +68,9 @@ describe("CourtListener REST adapter", () => {
 	it.each([
 		["an empty response", [], { kind: "malformed_response" }],
 		[
-			"a source-scoped absence",
+			"a conclusive absence for a different normalized citation",
 			[{ status: 404, normalized_citations: ["1 U.S. 200"], clusters: [] }],
-			{ kind: "absent", normalizedCitation: "347 U.S. 483" },
+			{ kind: "malformed_response" },
 		],
 		[
 			"an ambiguous item",

--- a/src/courtlistener/api.ts
+++ b/src/courtlistener/api.ts
@@ -177,8 +177,13 @@ function citationOutcome(
 	if (response.length === 0) return { kind: "malformed_response" };
 	const item = response[0];
 	if (item === undefined || response.length !== 1) return { kind: "malformed_response" };
+	const isRequestedCitation =
+		item.normalized_citations.length === 1 && item.normalized_citations[0] === input.normalized;
 	switch (item.status) {
 		case 200: {
+			if (!isRequestedCitation) {
+				return { kind: "malformed_response" };
+			}
 			const clusters = clusterMetadata(item.clusters);
 			return clusters.length === 0 || clusters.length !== item.clusters.length
 				? { kind: "malformed_response" }
@@ -189,7 +194,9 @@ function citationOutcome(
 		case 400:
 			return { kind: "unknown_reporter", normalizedCitation: input.normalized };
 		case 404:
-			return { kind: "absent", normalizedCitation: input.normalized };
+			return isRequestedCitation
+				? { kind: "absent", normalizedCitation: input.normalized }
+				: { kind: "malformed_response" };
 		case 429:
 			return { kind: "item_cap", normalizedCitation: input.normalized };
 		default:

--- a/src/courtlistener/gateway.ts
+++ b/src/courtlistener/gateway.ts
@@ -132,7 +132,7 @@ async function lookupReserved(
 				: record(
 						reservationToken,
 						{ kind: "success" },
-						{ kind: "verified", cluster, retrievedAt },
+						{ kind: "verified", cluster, freshness: "fresh", retrievedAt },
 						options,
 					);
 		}

--- a/src/verification/cached-citation-gateway-held-lease.test.ts
+++ b/src/verification/cached-citation-gateway-held-lease.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import type { CitationObservationStore } from "../cache/citation-observation-store.js";
+import { createCachedCitationGateway } from "./cached-citation-gateway.js";
+
+const NOW = new Date("2026-08-09T12:00:00.000Z");
+
+describe("cached citation gateway held leases", () => {
+	it("returns a rechecked source change while a held owner lease is still active", async () => {
+		// Given: the owner has durably stored a source reversal before its lease has expired.
+		let reads = 0;
+		let waits = 0;
+		const store: CitationObservationStore = {
+			read: async () => {
+				reads += 1;
+				return reads === 1
+					? null
+					: {
+							kind: "reversal_pending",
+							superseded: {
+								kind: "positive",
+								cluster: {
+									id: 123,
+									canonicalUrl: "https://www.courtlistener.com/opinion/123/example/",
+								},
+								retrievedAt: new Date("2026-07-01T12:00:00.000Z"),
+							},
+							firstNegative: {
+								kind: "negative",
+								retrievedAt: NOW,
+							},
+						};
+			},
+			acquireLease: async () => ({ kind: "held", expiresAt: "2026-08-09T12:00:10.000Z" }),
+			fillLease: async () => ({ kind: "lease_unavailable" }),
+			purgeExpiredNegativeLease: async () => ({ kind: "lease_unavailable" }),
+			releaseLease: async () => ({ kind: "lease_unavailable" }),
+		};
+		const gateway = createCachedCitationGateway({
+			now: () => NOW,
+			ownerToken: () => "waiter",
+			store,
+			upstream: {
+				lookup: async () => ({ kind: "not_found", retrievedAt: NOW.toISOString() }),
+			},
+			waitForFill: async () => {
+				waits += 1;
+			},
+		});
+
+		// When: the waiter rechecks the durable source state.
+		const result = await gateway.lookup({
+			volume: 347,
+			reporter: "U.S.",
+			page: 483,
+			normalizedCitation: "347 U.S. 483",
+		});
+
+		// Then: it returns the conservative source_changed result after one bounded recheck.
+		expect(result).toEqual({ kind: "indeterminate", reason: "source_changed" });
+		expect(waits).toBe(1);
+	});
+});

--- a/src/verification/cached-citation-gateway.test.ts
+++ b/src/verification/cached-citation-gateway.test.ts
@@ -128,6 +128,99 @@ describe("cached citation gateway", () => {
 		expect(result).toMatchObject({ kind: "verified", freshness: "fresh", cluster: { id: 456 } });
 	});
 
+	it("observes an owner fill after the initial held-lease recheck delay", async () => {
+		// Given: the held lease remains valid while its owner needs two recheck delays to fill D1.
+		let currentTime = NOW;
+		let filled = false;
+		let upstreamCalls = 0;
+		const waitDurations: number[] = [];
+		const gateway = createCachedCitationGateway({
+			now: () => currentTime,
+			ownerToken: () => "waiter",
+			store: {
+				...stalePositiveStore(),
+				read: async () =>
+					filled
+						? {
+								kind: "positive",
+								positive: {
+									kind: "positive",
+									cluster: {
+										id: 456,
+										canonicalUrl: "https://www.courtlistener.com/opinion/456/example/",
+									},
+									retrievedAt: currentTime,
+								},
+							}
+						: null,
+				acquireLease: async () => ({ kind: "held", expiresAt: "2026-08-09T12:00:00.200Z" }),
+			},
+			upstream: {
+				lookup: async () => {
+					upstreamCalls += 1;
+					return { kind: "not_found", retrievedAt: currentTime.toISOString() };
+				},
+			},
+			waitForFill: async (delayMilliseconds) => {
+				waitDurations.push(delayMilliseconds);
+				currentTime = new Date(currentTime.getTime() + delayMilliseconds);
+				filled = waitDurations.length === 2;
+			},
+		});
+
+		// When: the owner stores fresh evidence after more than one 50 ms recheck interval.
+		const result = await gateway.lookup({
+			volume: 347,
+			reporter: "U.S.",
+			page: 483,
+			normalizedCitation: "347 U.S. 483",
+		});
+
+		// Then: the waiter returns the owner fill and never duplicates the upstream request.
+		expect(result).toMatchObject({ kind: "verified", freshness: "fresh", cluster: { id: 456 } });
+		expect(waitDurations).toEqual([50, 100]);
+		expect(upstreamCalls).toBe(0);
+	});
+
+	it("fails closed when a held lease expires without an owner fill", async () => {
+		// Given: a held cache-miss lease whose owner never fills before its recorded expiry.
+		let currentTime = NOW;
+		const waitDurations: number[] = [];
+		let upstreamCalls = 0;
+		const gateway = createCachedCitationGateway({
+			now: () => currentTime,
+			ownerToken: () => "waiter",
+			store: {
+				...stalePositiveStore(),
+				read: async () => null,
+				acquireLease: async () => ({ kind: "held", expiresAt: "2026-08-09T12:00:00.300Z" }),
+			},
+			upstream: {
+				lookup: async () => {
+					upstreamCalls += 1;
+					return { kind: "not_found", retrievedAt: currentTime.toISOString() };
+				},
+			},
+			waitForFill: async (delayMilliseconds) => {
+				waitDurations.push(delayMilliseconds);
+				currentTime = new Date(currentTime.getTime() + delayMilliseconds);
+			},
+		});
+
+		// When: the waiter reaches the held lease expiry without observing a durable fill.
+		const result = await gateway.lookup({
+			volume: 347,
+			reporter: "U.S.",
+			page: 483,
+			normalizedCitation: "347 U.S. 483",
+		});
+
+		// Then: it stops at the lease deadline and reports only an unavailable verification outcome.
+		expect(result).toEqual({ kind: "indeterminate", reason: "upstream_unavailable" });
+		expect(waitDurations).toEqual([50, 100, 150]);
+		expect(upstreamCalls).toBe(0);
+	});
+
 	it("retains stale positive provenance when the D1 lease acquisition fails", async () => {
 		// Given: a retained positive that needs revalidation but whose D1 lease cannot be acquired.
 		const gateway = createCachedCitationGateway({

--- a/src/verification/cached-citation-gateway.test.ts
+++ b/src/verification/cached-citation-gateway.test.ts
@@ -25,11 +25,63 @@ function stalePositiveStore(): CitationObservationStore {
 			throw new Error("D1 unavailable");
 		},
 		fillLease: async () => ({ kind: "lease_unavailable" }),
+		purgeExpiredNegativeLease: async () => ({ kind: "lease_unavailable" }),
 		releaseLease: async () => ({ kind: "lease_unavailable" }),
 	};
 }
 
 describe("cached citation gateway", () => {
+	it("rechecks after acquiring a lease before deciding to call upstream", async () => {
+		// Given: another owner filled and released the cache between this caller's first read and lease acquisition.
+		let reads = 0;
+		let releases = 0;
+		const gateway = createCachedCitationGateway({
+			now: () => NOW,
+			ownerToken: () => "late-owner",
+			store: {
+				...stalePositiveStore(),
+				read: async () => {
+					reads += 1;
+					return reads === 1
+						? null
+						: {
+								kind: "positive",
+								positive: {
+									kind: "positive",
+									cluster: {
+										id: 456,
+										canonicalUrl: "https://www.courtlistener.com/opinion/456/example/",
+									},
+									retrievedAt: NOW,
+								},
+							};
+				},
+				acquireLease: async () => ({ kind: "acquired", expiresAt: "2026-08-09T12:00:10.000Z" }),
+				releaseLease: async () => {
+					releases += 1;
+					return { kind: "released" };
+				},
+			},
+			upstream: {
+				lookup: async () => {
+					throw new Error("upstream must not run");
+				},
+			},
+		});
+
+		// When: the caller owns the lease after the first owner has completed its fill.
+		const result = await gateway.lookup({
+			volume: 347,
+			reporter: "U.S.",
+			page: 483,
+			normalizedCitation: "347 U.S. 483",
+		});
+
+		// Then: the durable fill wins and the unnecessary lease is released without an upstream request.
+		expect(result).toMatchObject({ kind: "verified", freshness: "fresh", cluster: { id: 456 } });
+		expect(releases).toBe(1);
+	});
+
 	it("rechecks a durable fill for a held lease without calling upstream", async () => {
 		// Given: a waiter whose second D1 read sees the owner-filled positive state.
 		let reads = 0;

--- a/src/verification/cached-citation-gateway.test.ts
+++ b/src/verification/cached-citation-gateway.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { CitationObservationStore } from "../cache/citation-observation-store.js";
+import { DEFAULT_CITATION_SOURCE_CACHE_POLICY } from "./citation-source-cache.js";
+import { createCachedCitationGateway } from "./cached-citation-gateway.js";
+
+const NOW = new Date("2026-08-09T12:00:00.000Z");
+const RETRIEVED_AT = new Date(
+	NOW.getTime() - DEFAULT_CITATION_SOURCE_CACHE_POLICY.positiveFreshnessMs,
+);
+
+function stalePositiveStore(): CitationObservationStore {
+	return {
+		read: async () => ({
+			kind: "positive",
+			positive: {
+				kind: "positive",
+				cluster: {
+					id: 123,
+					canonicalUrl: "https://www.courtlistener.com/opinion/123/example/",
+				},
+				retrievedAt: RETRIEVED_AT,
+			},
+		}),
+		acquireLease: async () => {
+			throw new Error("D1 unavailable");
+		},
+		fillLease: async () => ({ kind: "lease_unavailable" }),
+		releaseLease: async () => ({ kind: "lease_unavailable" }),
+	};
+}
+
+describe("cached citation gateway", () => {
+	it("rechecks a durable fill for a held lease without calling upstream", async () => {
+		// Given: a waiter whose second D1 read sees the owner-filled positive state.
+		let reads = 0;
+		const gateway = createCachedCitationGateway({
+			now: () => NOW,
+			ownerToken: () => "waiter",
+			store: {
+				...stalePositiveStore(),
+				read: async () => {
+					reads += 1;
+					return reads === 1
+						? null
+						: {
+								kind: "positive",
+								positive: {
+									kind: "positive",
+									cluster: {
+										id: 456,
+										canonicalUrl: "https://www.courtlistener.com/opinion/456/example/",
+									},
+									retrievedAt: NOW,
+								},
+							};
+				},
+				acquireLease: async () => ({ kind: "held", expiresAt: "2026-08-09T12:00:10.000Z" }),
+			},
+			upstream: {
+				lookup: async () => {
+					throw new Error("upstream must not run");
+				},
+			},
+			waitForFill: async () => undefined,
+		});
+
+		// When: the bounded waiter rechecks after the lease owner fills D1.
+		const result = await gateway.lookup({
+			volume: 347,
+			reporter: "U.S.",
+			page: 483,
+			normalizedCitation: "347 U.S. 483",
+		});
+
+		// Then: it returns the filled evidence without a duplicate source request.
+		expect(result).toMatchObject({ kind: "verified", freshness: "fresh", cluster: { id: 456 } });
+	});
+
+	it("retains stale positive provenance when the D1 lease acquisition fails", async () => {
+		// Given: a retained positive that needs revalidation but whose D1 lease cannot be acquired.
+		const gateway = createCachedCitationGateway({
+			now: () => NOW,
+			ownerToken: () => "owner",
+			store: stalePositiveStore(),
+			upstream: { lookup: async () => ({ kind: "indeterminate", reason: "upstream_unavailable" }) },
+		});
+
+		// When: a caller asks for the stale citation.
+		const result = await gateway.lookup({
+			volume: 347,
+			reporter: "U.S.",
+			page: 483,
+			normalizedCitation: "347 U.S. 483",
+		});
+
+		// Then: only explicit stale evidence with its original retrieval time is returned.
+		expect(result).toEqual({
+			kind: "verified",
+			cluster: {
+				id: 123,
+				canonicalUrl: "https://www.courtlistener.com/opinion/123/example/",
+			},
+			freshness: "stale",
+			retrievedAt: RETRIEVED_AT.toISOString(),
+		});
+	});
+
+	it("retains stale positive provenance when the lease expires before fill", async () => {
+		// Given: a lease owner that gets a successful source observation but loses its lease before storing it.
+		const store = stalePositiveStore();
+		const gateway = createCachedCitationGateway({
+			now: () => NOW,
+			ownerToken: () => "owner",
+			store: {
+				...store,
+				acquireLease: async () => ({ kind: "acquired", expiresAt: "2026-08-09T12:00:10.000Z" }),
+			},
+			upstream: {
+				lookup: async () => ({ kind: "not_found", retrievedAt: NOW.toISOString() }),
+			},
+		});
+
+		// When: the owner loses its lease while filling the successful source observation.
+		const result = await gateway.lookup({
+			volume: 347,
+			reporter: "U.S.",
+			page: 483,
+			normalizedCitation: "347 U.S. 483",
+		});
+
+		// Then: it cannot accept the reversal and retains only the known stale positive.
+		expect(result).toMatchObject({
+			kind: "verified",
+			freshness: "stale",
+			retrievedAt: RETRIEVED_AT.toISOString(),
+		});
+	});
+});

--- a/src/verification/cached-citation-gateway.ts
+++ b/src/verification/cached-citation-gateway.ts
@@ -13,14 +13,15 @@ import type {
 	CitationVerificationObservation,
 } from "./verify-citation.js";
 
-const WAITER_RECHECK_DELAY_MS = 50;
+const WAITER_INITIAL_RECHECK_DELAY_MS = 50;
+const WAITER_MAX_RECHECK_DELAY_MS = 1_000;
 
 export type CachedCitationGatewayOptions = {
 	readonly now: () => Date;
 	readonly ownerToken: () => string;
 	readonly store: CitationObservationStore;
 	readonly upstream: CitationVerificationGateway;
-	readonly waitForFill?: () => Promise<void>;
+	readonly waitForFill?: (delayMilliseconds: number) => Promise<void>;
 };
 
 export function createCachedCitationGateway(
@@ -43,11 +44,29 @@ export function createCachedCitationGateway(
 					now,
 				});
 				if (lease.kind === "held") {
-					await (options.waitForFill ?? waitForFill)();
-					const rechecked = await options.store.read({
-						normalizedCitation: query.normalizedCitation,
-					});
-					return waiterObservation(rechecked, options.now(), decision);
+					const deadline = new Date(lease.expiresAt).getTime();
+					let delayMilliseconds = WAITER_INITIAL_RECHECK_DELAY_MS;
+					while (Number.isFinite(deadline)) {
+						const beforeWait = options.now().getTime();
+						const remainingMilliseconds = deadline - beforeWait;
+						if (remainingMilliseconds <= 0) break;
+						await (options.waitForFill ?? waitForFill)(
+							Math.min(delayMilliseconds, remainingMilliseconds),
+						);
+						const rechecked = await options.store.read({
+							normalizedCitation: query.normalizedCitation,
+						});
+						const recheckedDecision = readCitationSourceCache({
+							state: rechecked ?? { kind: "empty" },
+							now: options.now(),
+						});
+						const observation = waiterObservation(rechecked, options.now(), recheckedDecision);
+						if (observation.kind !== "indeterminate") return observation;
+						if (observation.reason === "source_changed") return observation;
+						if (options.now().getTime() <= beforeWait) break;
+						delayMilliseconds = Math.min(delayMilliseconds * 2, WAITER_MAX_RECHECK_DELAY_MS);
+					}
+					return waiterObservation(null, options.now(), decision);
 				}
 				const afterLease = await options.store.read({
 					normalizedCitation: query.normalizedCitation,
@@ -229,9 +248,9 @@ function unavailable(): CitationVerificationObservation {
 	return { kind: "indeterminate", reason: "upstream_unavailable" };
 }
 
-function waitForFill(): Promise<void> {
+function waitForFill(delayMilliseconds: number): Promise<void> {
 	return new Promise((resolve) => {
-		setTimeout(resolve, WAITER_RECHECK_DELAY_MS);
+		setTimeout(resolve, delayMilliseconds);
 	});
 }
 

--- a/src/verification/cached-citation-gateway.ts
+++ b/src/verification/cached-citation-gateway.ts
@@ -1,0 +1,178 @@
+import type {
+	CitationObservationStore,
+	LeaseFillResult,
+	StoredCitationObservation,
+} from "../cache/citation-observation-store.js";
+import {
+	readCitationSourceCache,
+	type CitationSourceCacheDecision,
+	type CitationSourceObservation,
+} from "./citation-source-cache.js";
+import type {
+	CitationVerificationGateway,
+	CitationVerificationObservation,
+} from "./verify-citation.js";
+
+const WAITER_RECHECK_DELAY_MS = 50;
+
+export type CachedCitationGatewayOptions = {
+	readonly now: () => Date;
+	readonly ownerToken: () => string;
+	readonly store: CitationObservationStore;
+	readonly upstream: CitationVerificationGateway;
+	readonly waitForFill?: () => Promise<void>;
+};
+
+export function createCachedCitationGateway(
+	options: CachedCitationGatewayOptions,
+): CitationVerificationGateway {
+	return {
+		async lookup(query): Promise<CitationVerificationObservation> {
+			let retainedFallback: CitationVerificationObservation | undefined;
+			try {
+				const cached = await options.store.read({ normalizedCitation: query.normalizedCitation });
+				const now = options.now();
+				const decision = readCitationSourceCache({ state: cached ?? { kind: "empty" }, now });
+				retainedFallback = retainedObservation(decision);
+				if (!requiresRevalidation(decision)) return observationFor(decision);
+
+				const ownerToken = options.ownerToken();
+				const lease = await options.store.acquireLease({
+					normalizedCitation: query.normalizedCitation,
+					ownerToken,
+					now,
+				});
+				if (lease.kind === "held") {
+					await (options.waitForFill ?? waitForFill)();
+					const rechecked = await options.store.read({
+						normalizedCitation: query.normalizedCitation,
+					});
+					return waiterObservation(rechecked, options.now(), decision);
+				}
+
+				const upstream = await options.upstream.lookup(query);
+				if (upstream.kind === "indeterminate") {
+					await options.store.releaseLease({
+						normalizedCitation: query.normalizedCitation,
+						ownerToken,
+					});
+					return fallbackObservation(decision, upstream);
+				}
+				const fill = await options.store.fillLease({
+					normalizedCitation: query.normalizedCitation,
+					ownerToken,
+					now: options.now(),
+					observation: sourceObservation(upstream),
+				});
+				return filledObservation(fill, options.now(), retainedFallback);
+			} catch (error) {
+				if (error instanceof Error) return retainedFallback ?? unavailable();
+				throw error;
+			}
+		},
+	};
+}
+
+function waiterObservation(
+	state: StoredCitationObservation | null,
+	now: Date,
+	prior: CitationSourceCacheDecision,
+): CitationVerificationObservation {
+	const decision = readCitationSourceCache({ state: state ?? { kind: "empty" }, now });
+	return requiresRevalidation(decision)
+		? fallbackObservation(prior, unavailable())
+		: observationFor(decision);
+}
+
+function filledObservation(
+	fill: LeaseFillResult,
+	now: Date,
+	retainedFallback: CitationVerificationObservation | undefined,
+): CitationVerificationObservation {
+	if (fill.kind === "lease_unavailable") return retainedFallback ?? unavailable();
+	return observationFor(readCitationSourceCache({ state: fill.observation, now }));
+}
+
+function fallbackObservation(
+	decision: CitationSourceCacheDecision,
+	upstream: CitationVerificationObservation,
+): CitationVerificationObservation {
+	return retainedObservation(decision) ?? upstream;
+}
+
+function retainedObservation(
+	decision: CitationSourceCacheDecision,
+): CitationVerificationObservation | undefined {
+	if (decision.kind === "verified" && decision.freshness === "stale")
+		return observationFor(decision);
+	if (decision.kind === "indeterminate" && decision.reason === "source_changed") {
+		return { kind: "indeterminate", reason: "source_changed" };
+	}
+	return undefined;
+}
+
+function observationFor(decision: CitationSourceCacheDecision): CitationVerificationObservation {
+	switch (decision.kind) {
+		case "verified":
+			return {
+				kind: "verified",
+				cluster: decision.positive.cluster,
+				freshness: decision.freshness,
+				retrievedAt: decision.positive.retrievedAt.toISOString(),
+			};
+		case "not_found":
+			return { kind: "not_found", retrievedAt: decision.negative.retrievedAt.toISOString() };
+		case "indeterminate":
+			switch (decision.reason) {
+				case "source_changed":
+					return { kind: "indeterminate", reason: "source_changed" };
+				case "cache_miss":
+				case "stale_negative":
+					return unavailable();
+				default:
+					return assertNever(decision.reason);
+			}
+		default:
+			return assertNever(decision);
+	}
+}
+
+function requiresRevalidation(decision: CitationSourceCacheDecision): boolean {
+	switch (decision.kind) {
+		case "verified":
+			return decision.requiresRevalidation;
+		case "not_found":
+			return false;
+		case "indeterminate":
+			return true;
+		default:
+			return assertNever(decision);
+	}
+}
+
+function sourceObservation(
+	observation: Exclude<CitationVerificationObservation, { readonly kind: "indeterminate" }>,
+): CitationSourceObservation {
+	switch (observation.kind) {
+		case "verified":
+			return { kind: "positive", cluster: observation.cluster };
+		case "not_found":
+			return { kind: "negative" };
+		default:
+			return assertNever(observation);
+	}
+}
+
+function unavailable(): CitationVerificationObservation {
+	return { kind: "indeterminate", reason: "upstream_unavailable" };
+}
+
+function waitForFill(): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, WAITER_RECHECK_DELAY_MS);
+	});
+}
+
+function assertNever(value: never): never {
+	throw new TypeError(`Unexpected cached citation value: ${String(value)}`);
+}

--- a/src/verification/cached-citation-gateway.ts
+++ b/src/verification/cached-citation-gateway.ts
@@ -49,6 +49,61 @@ export function createCachedCitationGateway(
 					});
 					return waiterObservation(rechecked, options.now(), decision);
 				}
+				const afterLease = await options.store.read({
+					normalizedCitation: query.normalizedCitation,
+				});
+				let current = readCitationSourceCache({
+					state: afterLease ?? { kind: "empty" },
+					now: options.now(),
+				});
+				retainedFallback = retainedObservation(current) ?? retainedFallback;
+				if (!requiresRevalidation(current)) {
+					await options.store.releaseLease({
+						normalizedCitation: query.normalizedCitation,
+						ownerToken,
+					});
+					return observationFor(current);
+				}
+				if (current.kind === "indeterminate" && current.reason === "stale_negative") {
+					const staleNegative = requireNegative(afterLease);
+					const purge = await options.store.purgeExpiredNegativeLease({
+						normalizedCitation: query.normalizedCitation,
+						ownerToken,
+						now: options.now(),
+						expected: staleNegative,
+					});
+					if (purge.kind === "lease_unavailable") return retainedFallback ?? unavailable();
+					if (purge.kind === "state_changed") {
+						const changed = await options.store.read({
+							normalizedCitation: query.normalizedCitation,
+						});
+						current = readCitationSourceCache({
+							state: changed ?? { kind: "empty" },
+							now: options.now(),
+						});
+						retainedFallback = retainedObservation(current) ?? retainedFallback;
+						if (!requiresRevalidation(current)) {
+							await options.store.releaseLease({
+								normalizedCitation: query.normalizedCitation,
+								ownerToken,
+							});
+							return observationFor(current);
+						}
+						if (current.kind === "indeterminate" && current.reason === "stale_negative") {
+							await options.store.releaseLease({
+								normalizedCitation: query.normalizedCitation,
+								ownerToken,
+							});
+							return unavailable();
+						}
+					} else {
+						current = readCitationSourceCache({
+							state: purge.observation ?? { kind: "empty" },
+							now: options.now(),
+						});
+						retainedFallback = retainedObservation(current) ?? retainedFallback;
+					}
+				}
 
 				const upstream = await options.upstream.lookup(query);
 				if (upstream.kind === "indeterminate") {
@@ -56,7 +111,7 @@ export function createCachedCitationGateway(
 						normalizedCitation: query.normalizedCitation,
 						ownerToken,
 					});
-					return fallbackObservation(decision, upstream);
+					return fallbackObservation(current, upstream);
 				}
 				const fill = await options.store.fillLease({
 					normalizedCitation: query.normalizedCitation,
@@ -71,6 +126,13 @@ export function createCachedCitationGateway(
 			}
 		},
 	};
+}
+
+function requireNegative(
+	state: StoredCitationObservation | null,
+): Extract<StoredCitationObservation, { readonly kind: "negative" }> {
+	if (state?.kind === "negative") return state;
+	throw new TypeError("stale negative decision requires a stored negative state");
 }
 
 function waiterObservation(

--- a/src/verification/citation-source-cache.test.ts
+++ b/src/verification/citation-source-cache.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
 	DEFAULT_CITATION_SOURCE_CACHE_POLICY,
 	initialCitationSourceCacheState,
+	purgeExpiredCitationNegative,
 	readCitationSourceCache,
 	recordCitationSourceObservation,
 } from "./citation-source-cache.js";
@@ -102,6 +103,20 @@ describe("citation source cache", () => {
 		});
 	});
 
+	it("purges an expired negative at the exact freshness boundary", () => {
+		// Given: a negative that has reached its retention boundary without superseded evidence.
+		const state = negative();
+
+		// When: the owner prepares the durable state for revalidation.
+		const purged = purgeExpiredCitationNegative({
+			state,
+			now: atOffset(START, DEFAULT_CITATION_SOURCE_CACHE_POLICY.negativeFreshnessMs),
+		});
+
+		// Then: no active negative observation remains to support a later result.
+		expect(purged).toEqual({ kind: "empty" });
+	});
+
 	it("requires a refresh for a cache miss", () => {
 		// Given: no durable observation for a normalized citation.
 		const state = initialCitationSourceCacheState();
@@ -169,6 +184,28 @@ describe("citation source cache", () => {
 			kind: "negative",
 			negative: { kind: "negative", retrievedAt: confirmedAt },
 			superseded: { kind: "positive", cluster: CLUSTER, retrievedAt: START },
+		});
+	});
+
+	it("turns an expired confirmed reversal into non-conclusive history", () => {
+		// Given: a confirmed negative that still retains the positive it superseded.
+		const confirmedAt = atOffset(
+			START,
+			DEFAULT_CITATION_SOURCE_CACHE_POLICY.reversalConfirmationMs,
+		);
+		const state = negative(negative(positive(), START), confirmedAt);
+
+		// When: the active negative reaches its freshness boundary.
+		const purged = purgeExpiredCitationNegative({
+			state,
+			now: atOffset(confirmedAt, DEFAULT_CITATION_SOURCE_CACHE_POLICY.negativeFreshnessMs),
+		});
+
+		// Then: the old positive remains superseded and the next negative must reconfirm it.
+		expect(purged).toEqual({
+			kind: "reversal_pending",
+			superseded: { kind: "positive", cluster: CLUSTER, retrievedAt: START },
+			firstNegative: { kind: "negative", retrievedAt: confirmedAt },
 		});
 	});
 

--- a/src/verification/citation-source-cache.test.ts
+++ b/src/verification/citation-source-cache.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, it } from "vitest";
+import {
+	DEFAULT_CITATION_SOURCE_CACHE_POLICY,
+	initialCitationSourceCacheState,
+	readCitationSourceCache,
+	recordCitationSourceObservation,
+} from "./citation-source-cache.js";
+
+const START = new Date("2026-08-09T12:00:00.000Z");
+const CLUSTER = {
+	id: 123,
+	canonicalUrl: "https://www.courtlistener.com/opinion/123/example/",
+} as const;
+
+function atOffset(start: Date, milliseconds: number): Date {
+	return new Date(start.getTime() + milliseconds);
+}
+
+function positive(state = initialCitationSourceCacheState(), now = START) {
+	return recordCitationSourceObservation({
+		state,
+		now,
+		observation: { kind: "positive", cluster: CLUSTER },
+	});
+}
+
+function negative(state = initialCitationSourceCacheState(), now = START) {
+	return recordCitationSourceObservation({ state, now, observation: { kind: "negative" } });
+}
+
+describe("citation source cache", () => {
+	it("returns a fresh positive for the thirty-day freshness window", () => {
+		// Given: a successful positive CourtListener observation.
+		const state = positive();
+
+		// When: it is read one millisecond before its default freshness expires.
+		const decision = readCitationSourceCache({
+			state,
+			now: atOffset(START, DEFAULT_CITATION_SOURCE_CACHE_POLICY.positiveFreshnessMs - 1),
+		});
+
+		// Then: it is a fresh verified result without a required revalidation.
+		expect(decision).toEqual({
+			kind: "verified",
+			freshness: "fresh",
+			requiresRevalidation: false,
+			positive: { kind: "positive", cluster: CLUSTER, retrievedAt: START },
+		});
+	});
+
+	it("retains an expired positive only as explicitly stale evidence", () => {
+		// Given: a retained positive observation at its freshness boundary.
+		const state = positive();
+
+		// When: it is read after thirty days.
+		const decision = readCitationSourceCache({
+			state,
+			now: atOffset(START, DEFAULT_CITATION_SOURCE_CACHE_POLICY.positiveFreshnessMs),
+		});
+
+		// Then: callers can disclose stale evidence and must revalidate it.
+		expect(decision).toEqual({
+			kind: "verified",
+			freshness: "stale",
+			requiresRevalidation: true,
+			positive: { kind: "positive", cluster: CLUSTER, retrievedAt: START },
+		});
+	});
+
+	it("uses a negative only while its twenty-four-hour freshness window remains", () => {
+		// Given: a successful source-scoped negative observation.
+		const state = negative();
+
+		// When: it is read one millisecond before expiry.
+		const decision = readCitationSourceCache({
+			state,
+			now: atOffset(START, DEFAULT_CITATION_SOURCE_CACHE_POLICY.negativeFreshnessMs - 1),
+		});
+
+		// Then: it can support a source-scoped not-found result.
+		expect(decision).toEqual({
+			kind: "not_found",
+			negative: { kind: "negative", retrievedAt: START },
+		});
+	});
+
+	it("never returns an expired negative as not-found evidence", () => {
+		// Given: an expired negative observation.
+		const state = negative();
+
+		// When: it is read at the freshness boundary.
+		const decision = readCitationSourceCache({
+			state,
+			now: atOffset(START, DEFAULT_CITATION_SOURCE_CACHE_POLICY.negativeFreshnessMs),
+		});
+
+		// Then: the cache requires a refresh rather than claiming source absence.
+		expect(decision).toEqual({
+			kind: "indeterminate",
+			reason: "stale_negative",
+			requiresRevalidation: true,
+		});
+	});
+
+	it("requires a refresh for a cache miss", () => {
+		// Given: no durable observation for a normalized citation.
+		const state = initialCitationSourceCacheState();
+
+		// When: the source cache is read.
+		const decision = readCitationSourceCache({ state, now: START });
+
+		// Then: the caller must obtain a successful upstream observation.
+		expect(decision).toEqual({
+			kind: "indeterminate",
+			reason: "cache_miss",
+			requiresRevalidation: true,
+		});
+	});
+
+	it("preserves positive evidence and reports source_changed after a contradictory negative", () => {
+		// Given: retained positive evidence and a later successful source negative.
+		const state = negative(positive(), atOffset(START, 1_000));
+
+		// When: the changed source state is read.
+		const decision = readCitationSourceCache({ state, now: atOffset(START, 1_000) });
+
+		// Then: verification stops conclusively while the superseded positive remains durable.
+		expect(state).toEqual({
+			kind: "reversal_pending",
+			superseded: { kind: "positive", cluster: CLUSTER, retrievedAt: START },
+			firstNegative: { kind: "negative", retrievedAt: atOffset(START, 1_000) },
+		});
+		expect(decision).toEqual({
+			kind: "indeterminate",
+			reason: "source_changed",
+			requiresRevalidation: true,
+		});
+	});
+
+	it("requires a second negative at least twenty-four hours after the first before accepting reversal", () => {
+		// Given: a positive contradicted by its first negative observation.
+		const firstNegativeAt = atOffset(START, 1_000);
+		const pending = negative(positive(), firstNegativeAt);
+
+		// When: another successful negative arrives before the confirmation window.
+		const stillPending = negative(
+			pending,
+			atOffset(firstNegativeAt, DEFAULT_CITATION_SOURCE_CACHE_POLICY.reversalConfirmationMs - 1),
+		);
+
+		// Then: the retained positive cannot be replaced yet.
+		expect(stillPending).toEqual(pending);
+	});
+
+	it("accepts a confirmed negative reversal after twenty-four hours", () => {
+		// Given: a positive contradicted by its first negative observation.
+		const firstNegativeAt = atOffset(START, 1_000);
+		const pending = negative(positive(), firstNegativeAt);
+		const confirmedAt = atOffset(
+			firstNegativeAt,
+			DEFAULT_CITATION_SOURCE_CACHE_POLICY.reversalConfirmationMs,
+		);
+
+		// When: a second successful negative arrives at the confirmation boundary.
+		const state = negative(pending, confirmedAt);
+
+		// Then: the confirmed fresh negative retains its superseded positive metadata.
+		expect(state).toEqual({
+			kind: "negative",
+			negative: { kind: "negative", retrievedAt: confirmedAt },
+			superseded: { kind: "positive", cluster: CLUSTER, retrievedAt: START },
+		});
+	});
+
+	it("restores positive evidence immediately when a changed source supports it again", () => {
+		// Given: a source reversal awaiting confirmation.
+		const pending = negative(positive(), atOffset(START, 1_000));
+		const renewedAt = atOffset(START, 2_000);
+
+		// When: the source returns positive evidence again.
+		const state = positive(pending, renewedAt);
+
+		// Then: normal fresh positive operation resumes immediately.
+		expect(state).toEqual({
+			kind: "positive",
+			positive: { kind: "positive", cluster: CLUSTER, retrievedAt: renewedAt },
+		});
+	});
+});

--- a/src/verification/citation-source-cache.ts
+++ b/src/verification/citation-source-cache.ts
@@ -71,6 +71,8 @@ export type CitationSourceObservationRecord = {
 	readonly policy?: CitationSourceCachePolicy;
 };
 
+export type CitationSourceNegativePurge = CitationSourceCacheRead;
+
 export function initialCitationSourceCacheState(): CitationSourceCacheState {
 	return { kind: "empty" };
 }
@@ -137,6 +139,24 @@ export function recordCitationSourceObservation(
 		default:
 			return assertNever(input.state);
 	}
+}
+
+export function purgeExpiredCitationNegative(
+	input: CitationSourceNegativePurge,
+): CitationSourceCacheState {
+	const policy = input.policy ?? DEFAULT_CITATION_SOURCE_CACHE_POLICY;
+	if (
+		input.state.kind !== "negative" ||
+		isFresh(input.state.negative.retrievedAt, input.now, policy.negativeFreshnessMs)
+	)
+		return input.state;
+	return input.state.superseded === null
+		? initialCitationSourceCacheState()
+		: {
+				kind: "reversal_pending",
+				superseded: input.state.superseded,
+				firstNegative: input.state.negative,
+			};
 }
 
 function withRetrievedAt(

--- a/src/verification/citation-source-cache.ts
+++ b/src/verification/citation-source-cache.ts
@@ -1,0 +1,197 @@
+export const DEFAULT_CITATION_SOURCE_CACHE_POLICY = {
+	positiveFreshnessMs: 30 * 24 * 60 * 60 * 1_000,
+	negativeFreshnessMs: 24 * 60 * 60 * 1_000,
+	reversalConfirmationMs: 24 * 60 * 60 * 1_000,
+} as const;
+
+export type CitationSourceCachePolicy = {
+	readonly positiveFreshnessMs: number;
+	readonly negativeFreshnessMs: number;
+	readonly reversalConfirmationMs: number;
+};
+
+export type CitationSourceCluster = {
+	readonly id: number;
+	readonly canonicalUrl: string;
+};
+
+export type PositiveCitationObservation = {
+	readonly kind: "positive";
+	readonly cluster: CitationSourceCluster;
+	readonly retrievedAt: Date;
+};
+
+export type NegativeCitationObservation = {
+	readonly kind: "negative";
+	readonly retrievedAt: Date;
+};
+
+export type CitationSourceObservation =
+	| Omit<PositiveCitationObservation, "retrievedAt">
+	| Omit<NegativeCitationObservation, "retrievedAt">;
+
+export type CitationSourceCacheState =
+	| { readonly kind: "empty" }
+	| { readonly kind: "positive"; readonly positive: PositiveCitationObservation }
+	| {
+			readonly kind: "negative";
+			readonly negative: NegativeCitationObservation;
+			readonly superseded: PositiveCitationObservation | null;
+	  }
+	| {
+			readonly kind: "reversal_pending";
+			readonly superseded: PositiveCitationObservation;
+			readonly firstNegative: NegativeCitationObservation;
+	  };
+
+export type CitationSourceCacheDecision =
+	| {
+			readonly kind: "verified";
+			readonly freshness: "fresh" | "stale";
+			readonly requiresRevalidation: boolean;
+			readonly positive: PositiveCitationObservation;
+	  }
+	| { readonly kind: "not_found"; readonly negative: NegativeCitationObservation }
+	| {
+			readonly kind: "indeterminate";
+			readonly reason: "cache_miss" | "stale_negative" | "source_changed";
+			readonly requiresRevalidation: true;
+	  };
+
+export type CitationSourceCacheRead = {
+	readonly state: CitationSourceCacheState;
+	readonly now: Date;
+	readonly policy?: CitationSourceCachePolicy;
+};
+
+export type CitationSourceObservationRecord = {
+	readonly state: CitationSourceCacheState;
+	readonly observation: CitationSourceObservation;
+	readonly now: Date;
+	readonly policy?: CitationSourceCachePolicy;
+};
+
+export function initialCitationSourceCacheState(): CitationSourceCacheState {
+	return { kind: "empty" };
+}
+
+export function readCitationSourceCache(
+	input: CitationSourceCacheRead,
+): CitationSourceCacheDecision {
+	const policy = input.policy ?? DEFAULT_CITATION_SOURCE_CACHE_POLICY;
+	switch (input.state.kind) {
+		case "empty":
+			return refreshRequired("cache_miss");
+		case "positive":
+			return positiveDecision(input.state.positive, input.now, policy);
+		case "negative":
+			return isFresh(input.state.negative.retrievedAt, input.now, policy.negativeFreshnessMs)
+				? { kind: "not_found", negative: input.state.negative }
+				: refreshRequired("stale_negative");
+		case "reversal_pending":
+			return refreshRequired("source_changed");
+		default:
+			return assertNever(input.state);
+	}
+}
+
+export function recordCitationSourceObservation(
+	input: CitationSourceObservationRecord,
+): CitationSourceCacheState {
+	const policy = input.policy ?? DEFAULT_CITATION_SOURCE_CACHE_POLICY;
+	const observation = withRetrievedAt(input.observation, input.now);
+	switch (input.state.kind) {
+		case "empty":
+			return stateFor(observation);
+		case "positive":
+			return observation.kind === "positive"
+				? stateFor(observation)
+				: {
+						kind: "reversal_pending",
+						superseded: input.state.positive,
+						firstNegative: observation,
+					};
+		case "negative":
+			return observation.kind === "positive"
+				? stateFor(observation)
+				: { kind: "negative", negative: observation, superseded: input.state.superseded };
+		case "reversal_pending":
+			switch (observation.kind) {
+				case "positive":
+					return stateFor(observation);
+				case "negative":
+					return isFresh(
+						input.state.firstNegative.retrievedAt,
+						input.now,
+						policy.reversalConfirmationMs,
+					)
+						? input.state
+						: {
+								kind: "negative",
+								negative: observation,
+								superseded: input.state.superseded,
+							};
+				default:
+					return assertNever(observation);
+			}
+		default:
+			return assertNever(input.state);
+	}
+}
+
+function withRetrievedAt(
+	observation: CitationSourceObservation,
+	now: Date,
+): PositiveCitationObservation | NegativeCitationObservation {
+	switch (observation.kind) {
+		case "positive":
+			return { ...observation, retrievedAt: now };
+		case "negative":
+			return { ...observation, retrievedAt: now };
+		default:
+			return assertNever(observation);
+	}
+}
+
+function stateFor(
+	observation: PositiveCitationObservation | NegativeCitationObservation,
+): CitationSourceCacheState {
+	switch (observation.kind) {
+		case "positive":
+			return { kind: "positive", positive: observation };
+		case "negative":
+			return { kind: "negative", negative: observation, superseded: null };
+		default:
+			return assertNever(observation);
+	}
+}
+
+function positiveDecision(
+	positive: PositiveCitationObservation,
+	now: Date,
+	policy: CitationSourceCachePolicy,
+): CitationSourceCacheDecision {
+	const freshness = isFresh(positive.retrievedAt, now, policy.positiveFreshnessMs)
+		? "fresh"
+		: "stale";
+	return {
+		kind: "verified",
+		freshness,
+		requiresRevalidation: freshness === "stale",
+		positive,
+	};
+}
+
+function refreshRequired(
+	reason: Extract<CitationSourceCacheDecision, { readonly kind: "indeterminate" }>["reason"],
+): CitationSourceCacheDecision {
+	return { kind: "indeterminate", reason, requiresRevalidation: true };
+}
+
+function isFresh(retrievedAt: Date, now: Date, freshnessMs: number): boolean {
+	return now.getTime() - retrievedAt.getTime() < freshnessMs;
+}
+
+function assertNever(value: never): never {
+	throw new TypeError(`Unexpected citation source-cache value: ${String(value)}`);
+}

--- a/src/verification/indeterminate.ts
+++ b/src/verification/indeterminate.ts
@@ -73,6 +73,7 @@ function citationText(result: VerifyCitationResult): string {
 				case "timeout":
 				case "upstream_unavailable":
 				case "quota_unknown":
+				case "source_changed":
 				case "rate_limited":
 				case "circuit_open":
 					return "Citation verification is temporarily unavailable.";

--- a/src/verification/verify-citation.test.ts
+++ b/src/verification/verify-citation.test.ts
@@ -34,6 +34,7 @@ describe("verifyCitation", () => {
 				id: 12345,
 				canonicalUrl: "https://www.courtlistener.com/opinion/12345/example/",
 			},
+			freshness: "fresh",
 			retrievedAt: retrievalTime,
 		});
 
@@ -75,6 +76,28 @@ describe("verifyCitation", () => {
 		expect(calls).toHaveLength(1);
 	});
 
+	it("discloses retained positive evidence as stale after failed revalidation", async () => {
+		// Given: a cache gateway that retained positive evidence beyond its freshness window.
+		const { gateway } = gatewayThat({
+			kind: "verified",
+			cluster: {
+				id: 12345,
+				canonicalUrl: "https://www.courtlistener.com/opinion/12345/example/",
+			},
+			freshness: "stale",
+			retrievedAt: retrievalTime,
+		});
+
+		// When: a supported citation is verified from that retained evidence.
+		const result = await verifyCitation({ citation: "347 U.S. 483" }, gateway);
+
+		// Then: the original retrieval time is disclosed without a silent fresh claim.
+		expect(result).toMatchObject({
+			outcome: "verified",
+			evidence: { freshness: "stale", retrievedAt: retrievalTime },
+		});
+	});
+
 	it("returns unsupported_citation locally without contacting the gateway", async () => {
 		const { gateway, calls } = gatewayThat({ kind: "not_found", retrievedAt: retrievalTime });
 
@@ -94,6 +117,7 @@ describe("verifyCitation", () => {
 		["timeout", undefined],
 		["upstream_unavailable", undefined],
 		["quota_unknown", undefined],
+		["source_changed", undefined],
 		["rate_limited", 60],
 		["circuit_open", 30],
 	] as const)("maps %s to sanitized retry guidance", async (reason, retryAfterSeconds) => {
@@ -137,6 +161,30 @@ describe("verify_citation contract schemas", () => {
 						canonicalUrl: "https://www.courtlistener.com/opinion/12345/example/",
 					},
 				},
+			}).success,
+		).toBe(true);
+		expect(
+			verifyCitationOutputSchema.safeParse({
+				outcome: "verified",
+				contractVersion: CONTRACT_VERSION,
+				evidence: {
+					source: "courtlistener",
+					normalizedCitation: "347 U.S. 483",
+					retrievedAt: retrievalTime,
+					freshness: "stale",
+					cluster: {
+						id: 12345,
+						canonicalUrl: "https://www.courtlistener.com/opinion/12345/example/",
+					},
+				},
+			}).success,
+		).toBe(true);
+		expect(
+			verifyCitationOutputSchema.safeParse({
+				outcome: "indeterminate",
+				contractVersion: CONTRACT_VERSION,
+				reason: "source_changed",
+				retry: { action: "retry_later" },
 			}).success,
 		).toBe(true);
 		expect(

--- a/src/verification/verify-citation.ts
+++ b/src/verification/verify-citation.ts
@@ -16,7 +16,7 @@ const evidenceSchema = z
 		source: z.literal("courtlistener"),
 		normalizedCitation: z.string().min(1),
 		retrievedAt: z.iso.datetime(),
-		freshness: z.literal("fresh"),
+		freshness: z.enum(["fresh", "stale"]),
 	})
 	.strict();
 
@@ -66,7 +66,13 @@ const retryableCitationResultSchema = z
 	.object({
 		outcome: z.literal("indeterminate"),
 		contractVersion: z.literal(CONTRACT_VERSION),
-		reason: z.enum(["incomplete", "timeout", "upstream_unavailable", "quota_unknown"]),
+		reason: z.enum([
+			"incomplete",
+			"timeout",
+			"upstream_unavailable",
+			"quota_unknown",
+			"source_changed",
+		]),
 		retry: retryLaterSchema,
 	})
 	.strict();
@@ -104,16 +110,24 @@ export type CourtListenerCluster = {
 	readonly canonicalUrl: string;
 };
 
+type RetryableCitationReason =
+	| "incomplete"
+	| "timeout"
+	| "upstream_unavailable"
+	| "quota_unknown"
+	| "source_changed";
+
 export type CitationVerificationObservation =
 	| {
 			readonly kind: "verified";
 			readonly cluster: CourtListenerCluster;
+			readonly freshness: "fresh" | "stale";
 			readonly retrievedAt: string;
 	  }
 	| { readonly kind: "not_found"; readonly retrievedAt: string }
 	| {
 			readonly kind: "indeterminate";
-			readonly reason: "incomplete" | "timeout" | "upstream_unavailable" | "quota_unknown";
+			readonly reason: RetryableCitationReason;
 	  }
 	| {
 			readonly kind: "indeterminate";
@@ -129,7 +143,7 @@ type EvidenceProvenance = {
 	readonly source: "courtlistener";
 	readonly normalizedCitation: string;
 	readonly retrievedAt: string;
-	readonly freshness: "fresh";
+	readonly freshness: "fresh" | "stale";
 };
 
 export type VerifyCitationResult =
@@ -152,7 +166,7 @@ export type VerifyCitationResult =
 	| {
 			readonly outcome: "indeterminate";
 			readonly contractVersion: typeof CONTRACT_VERSION;
-			readonly reason: "incomplete" | "timeout" | "upstream_unavailable" | "quota_unknown";
+			readonly reason: RetryableCitationReason;
 			readonly retry: { readonly action: "retry_later" };
 	  }
 	| {
@@ -176,13 +190,12 @@ export const verifyCitationToolDefinition = {
 	},
 } as const;
 
-function freshEvidence(normalizedCitation: string, retrievedAt: string): EvidenceProvenance {
-	return {
-		source: "courtlistener",
-		normalizedCitation,
-		retrievedAt,
-		freshness: "fresh",
-	};
+function evidenceProvenance(
+	normalizedCitation: string,
+	retrievedAt: string,
+	freshness: EvidenceProvenance["freshness"],
+): EvidenceProvenance {
+	return { source: "courtlistener", normalizedCitation, retrievedAt, freshness };
 }
 
 export async function verifyCitation(
@@ -212,7 +225,11 @@ export async function verifyCitation(
 				outcome: "verified",
 				contractVersion: CONTRACT_VERSION,
 				evidence: {
-					...freshEvidence(parsed.citation.normalized, observation.retrievedAt),
+					...evidenceProvenance(
+						parsed.citation.normalized,
+						observation.retrievedAt,
+						observation.freshness,
+					),
 					cluster: observation.cluster,
 				},
 			};
@@ -221,7 +238,7 @@ export async function verifyCitation(
 				outcome: "not_found",
 				contractVersion: CONTRACT_VERSION,
 				evidence: {
-					...freshEvidence(parsed.citation.normalized, observation.retrievedAt),
+					...evidenceProvenance(parsed.citation.normalized, observation.retrievedAt, "fresh"),
 					searchComplete: true,
 				},
 			};
@@ -244,6 +261,7 @@ export async function verifyCitation(
 				case "timeout":
 				case "upstream_unavailable":
 				case "quota_unknown":
+				case "source_changed":
 					return {
 						outcome: "indeterminate",
 						contractVersion: CONTRACT_VERSION,

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -3,11 +3,13 @@ import {
 	authenticateRequest,
 	createAuthenticationFailureResponse,
 } from "./auth/api-key.js";
+import { createD1CitationObservationStore } from "./cache/d1-citation-observation-store.js";
 import { createCourtListenerApi } from "./courtlistener/api.js";
 import type { CourtListenerCoordinatorRpc } from "./courtlistener/coordinator.js";
 import { createCourtListenerCitationGateway } from "./courtlistener/gateway.js";
 import { createLexCertaMcpHandler, protocolBoundaryRejection } from "./mcp.js";
 import { boundedMcpRequest } from "./request-body.js";
+import { createCachedCitationGateway } from "./verification/cached-citation-gateway.js";
 import type { CitationVerificationGateway } from "./verification/verify-citation.js";
 
 export { ApiKeyLimiter } from "./admission/api-key-limiter.js";
@@ -42,6 +44,7 @@ type CourtListenerEnvironment = {
 
 export type Env = {
 	readonly BUILD_ID: string;
+	readonly DB: D1Database;
 	readonly API_KEY_LIMITER: ApiKeyLimiterNamespace;
 } & AuthEnvironment &
 	CourtListenerEnvironment;
@@ -92,6 +95,15 @@ function unavailableCitationGateway(): CitationVerificationGateway {
 }
 
 function citationGateway(env: Env): CitationVerificationGateway {
+	return createCachedCitationGateway({
+		now: () => new Date(),
+		ownerToken: () => crypto.randomUUID(),
+		store: createD1CitationObservationStore(env.DB),
+		upstream: upstreamCitationGateway(env),
+	});
+}
+
+function upstreamCitationGateway(env: Env): CitationVerificationGateway {
 	const token = env.COURTLISTENER_API_TOKEN;
 	const credentialId = env.COURTLISTENER_CREDENTIAL_ID;
 	const coordinator = env.COURTLISTENER_COORDINATOR;

--- a/test/citation-observation-store.integration.test.ts
+++ b/test/citation-observation-store.integration.test.ts
@@ -1,0 +1,267 @@
+import { env } from "cloudflare:test";
+import { beforeEach, describe, expect, it } from "vitest";
+import migration from "../migrations/0004_citation_source_cache.sql?raw";
+import type {
+	LeaseFillResult,
+	StoredCitationObservation,
+} from "../src/cache/citation-observation-store.js";
+import { CITATION_FETCH_LEASE_MS } from "../src/cache/citation-observation-store.js";
+import {
+	CitationSourceStateCorruptError,
+	createD1CitationObservationStore,
+} from "../src/cache/d1-citation-observation-store.js";
+
+const NOW = new Date("2026-08-09T12:00:00.000Z");
+const CITATION = "347 U.S. 483";
+const OWNER = "fetch-owner-a";
+
+function at(milliseconds: number): Date {
+	return new Date(NOW.getTime() + milliseconds);
+}
+
+function positiveObservation() {
+	return {
+		kind: "positive" as const,
+		cluster: { id: 123, canonicalUrl: "https://www.courtlistener.com/opinion/123/example/" },
+	};
+}
+
+function storedObservation(result: LeaseFillResult): StoredCitationObservation {
+	if (result.kind === "stored") return result.observation;
+	throw new TypeError("expected an active lease owner to store an observation");
+}
+
+async function reset(): Promise<void> {
+	await env.DB.prepare("DROP TABLE IF EXISTS citation_fetch_leases").run();
+	await env.DB.prepare("DROP TABLE IF EXISTS citation_source_states").run();
+	for (const statement of migration
+		.split(";")
+		.map((value) => value.trim())
+		.filter(Boolean)) {
+		await env.DB.prepare(statement).run();
+	}
+}
+
+describe("D1 citation observation store", () => {
+	beforeEach(reset);
+
+	it("uses a ten-second lease that remains longer than the upstream timeout", () => {
+		// Given: the fixed upstream timeout is five seconds.
+		const upstreamTimeoutMs = 5_000;
+
+		// When: the source-cache lease policy is inspected.
+		const leaseDurationMs = CITATION_FETCH_LEASE_MS;
+
+		// Then: in-flight upstream work cannot normally lose its owner lease.
+		expect(leaseDurationMs).toBe(10_000);
+		expect(leaseDurationMs).toBeGreaterThan(upstreamTimeoutMs);
+	});
+
+	it("persists a positive observation only when its active lease owner fills it", async () => {
+		// Given: an empty D1 source cache and an owner that acquired the normalized citation lease.
+		const store = createD1CitationObservationStore(env.DB);
+		await expect(
+			store.acquireLease({ normalizedCitation: CITATION, ownerToken: OWNER, now: NOW }),
+		).resolves.toEqual({
+			kind: "acquired",
+			expiresAt: "2026-08-09T12:00:10.000Z",
+		});
+
+		// When: that owner records a successful positive CourtListener observation.
+		const result = await store.fillLease({
+			normalizedCitation: CITATION,
+			ownerToken: OWNER,
+			now: NOW,
+			observation: positiveObservation(),
+		});
+
+		// Then: D1 returns the pure positive state with retrieval metadata and releases the lease.
+		expect(result).toEqual({
+			kind: "stored",
+			observation: {
+				kind: "positive",
+				positive: {
+					kind: "positive",
+					cluster: {
+						id: 123,
+						canonicalUrl: "https://www.courtlistener.com/opinion/123/example/",
+					},
+					retrievedAt: NOW,
+				},
+			},
+		});
+		await expect(store.read({ normalizedCitation: CITATION })).resolves.toEqual(
+			storedObservation(result),
+		);
+		await expect(
+			store.acquireLease({ normalizedCitation: CITATION, ownerToken: OWNER, now: NOW }),
+		).resolves.toMatchObject({
+			kind: "acquired",
+		});
+	});
+
+	it("coalesces concurrent misses so exactly one owner obtains the lease", async () => {
+		// Given: sixteen simultaneous callers for one normalized citation.
+		const store = createD1CitationObservationStore(env.DB);
+
+		// When: every caller tries to acquire the same D1 fetch lease.
+		const results = await Promise.all(
+			Array.from({ length: 16 }, (_, index) =>
+				store.acquireLease({
+					normalizedCitation: CITATION,
+					ownerToken: `owner-${index}`,
+					now: NOW,
+				}),
+			),
+		);
+
+		// Then: one caller fetches while all other callers receive the held deadline.
+		expect(results.filter((result) => result.kind === "acquired")).toHaveLength(1);
+		expect(results.filter((result) => result.kind === "held")).toHaveLength(15);
+	});
+
+	it("lets a waiting caller recheck the durable fill after the active owner completes", async () => {
+		// Given: a waiting caller receives the held deadline while another owner fetches.
+		const store = createD1CitationObservationStore(env.DB);
+		await store.acquireLease({ normalizedCitation: CITATION, ownerToken: OWNER, now: NOW });
+		await expect(
+			store.acquireLease({ normalizedCitation: CITATION, ownerToken: "waiter", now: NOW }),
+		).resolves.toMatchObject({ kind: "held" });
+
+		// When: the active owner stores its successful source observation.
+		await store.fillLease({
+			normalizedCitation: CITATION,
+			ownerToken: OWNER,
+			now: NOW,
+			observation: positiveObservation(),
+		});
+
+		// Then: the waiter can recheck D1 without issuing a duplicate upstream request.
+		await expect(store.read({ normalizedCitation: CITATION })).resolves.toMatchObject({
+			kind: "positive",
+		});
+	});
+
+	it("allows only the current owner to release a fetch lease", async () => {
+		// Given: one active normalized-citation lease.
+		const store = createD1CitationObservationStore(env.DB);
+		await store.acquireLease({ normalizedCitation: CITATION, ownerToken: OWNER, now: NOW });
+
+		// When: another owner attempts the release before the true owner does.
+		const otherRelease = await store.releaseLease({
+			normalizedCitation: CITATION,
+			ownerToken: "other-owner",
+		});
+		const ownerRelease = await store.releaseLease({
+			normalizedCitation: CITATION,
+			ownerToken: OWNER,
+		});
+
+		// Then: only the owner can release it for a fresh acquisition.
+		expect(otherRelease).toEqual({ kind: "lease_unavailable" });
+		expect(ownerRelease).toEqual({ kind: "released" });
+	});
+
+	it("recovers an expired lease and rejects a late former-owner fill", async () => {
+		// Given: a first owner holds a lease that has not expired one millisecond before its deadline.
+		const store = createD1CitationObservationStore(env.DB);
+		await store.acquireLease({ normalizedCitation: CITATION, ownerToken: OWNER, now: NOW });
+		await expect(
+			store.acquireLease({ normalizedCitation: CITATION, ownerToken: "owner-b", now: at(9_999) }),
+		).resolves.toEqual({ kind: "held", expiresAt: "2026-08-09T12:00:10.000Z" });
+
+		// When: the deadline is reached and a second owner takes over before the former owner fills.
+		await expect(
+			store.acquireLease({ normalizedCitation: CITATION, ownerToken: "owner-b", now: at(10_000) }),
+		).resolves.toEqual({ kind: "acquired", expiresAt: "2026-08-09T12:00:20.000Z" });
+		const late = await store.fillLease({
+			normalizedCitation: CITATION,
+			ownerToken: OWNER,
+			now: at(10_000),
+			observation: positiveObservation(),
+		});
+
+		// Then: only the active owner can persist a successful source observation.
+		expect(late).toEqual({ kind: "lease_unavailable" });
+		await expect(store.read({ normalizedCitation: CITATION })).resolves.toBeNull();
+	});
+
+	it("persists a confirmed negative reversal with the superseded positive metadata", async () => {
+		// Given: positive evidence followed by a successful contradictory negative observation.
+		const store = createD1CitationObservationStore(env.DB);
+		await store.acquireLease({ normalizedCitation: CITATION, ownerToken: OWNER, now: NOW });
+		await store.fillLease({
+			normalizedCitation: CITATION,
+			ownerToken: OWNER,
+			now: NOW,
+			observation: positiveObservation(),
+		});
+		await store.acquireLease({
+			normalizedCitation: CITATION,
+			ownerToken: "owner-b",
+			now: at(1_000),
+		});
+		await store.fillLease({
+			normalizedCitation: CITATION,
+			ownerToken: "owner-b",
+			now: at(1_000),
+			observation: { kind: "negative" },
+		});
+
+		// When: a second successful negative arrives exactly twenty-four hours after the first.
+		await store.acquireLease({
+			normalizedCitation: CITATION,
+			ownerToken: "owner-c",
+			now: at(86_401_000),
+		});
+		const recorded = await store.fillLease({
+			normalizedCitation: CITATION,
+			ownerToken: "owner-c",
+			now: at(86_401_000),
+			observation: { kind: "negative" },
+		});
+
+		// Then: D1 retains the confirmed negative and the superseded positive provenance.
+		expect(recorded).toEqual({
+			kind: "stored",
+			observation: {
+				kind: "negative",
+				negative: { kind: "negative", retrievedAt: at(86_401_000) },
+				superseded: {
+					kind: "positive",
+					cluster: positiveObservation().cluster,
+					retrievedAt: NOW,
+				},
+			},
+		});
+		await expect(store.read({ normalizedCitation: CITATION })).resolves.toEqual(
+			storedObservation(recorded),
+		);
+	});
+
+	it("rejects corrupt non-CourtListener provenance without exposing the citation", async () => {
+		// Given: a D1 row corrupted with an untrusted canonical URL.
+		await env.DB.prepare(
+			"INSERT INTO citation_source_states (normalized_citation, state_json, updated_at) VALUES (?1, ?2, ?3)",
+		)
+			.bind(
+				CITATION,
+				JSON.stringify({
+					kind: "positive",
+					positive: {
+						kind: "positive",
+						cluster: { id: 123, canonicalUrl: "https://example.invalid/opinion/123/" },
+						retrievedAt: NOW,
+					},
+				}),
+				NOW.toISOString(),
+			)
+			.run();
+
+		// When: the D1 store reads that provenance boundary.
+		const read = createD1CitationObservationStore(env.DB).read({ normalizedCitation: CITATION });
+
+		// Then: it fails generically rather than returning attacker-controlled metadata.
+		await expect(read).rejects.toEqual(new CitationSourceStateCorruptError());
+	});
+});

--- a/test/config-migration.integration.test.ts
+++ b/test/config-migration.integration.test.ts
@@ -3,6 +3,7 @@ import { beforeAll, describe, expect, it } from "vitest";
 import apiKeyMigrationSql from "../migrations/0001_api_key_records.sql?raw";
 import adminLifecycleMigrationSql from "../migrations/0002_admin_key_lifecycle.sql?raw";
 import limitsVersionMigrationSql from "../migrations/0003_api_key_limit_version.sql?raw";
+import citationSourceCacheMigrationSql from "../migrations/0004_citation_source_cache.sql?raw";
 
 describe("isolated Worker configuration and D1 migrations", () => {
 	beforeAll(async () => {
@@ -10,6 +11,7 @@ describe("isolated Worker configuration and D1 migrations", () => {
 			apiKeyMigrationSql,
 			adminLifecycleMigrationSql,
 			limitsVersionMigrationSql,
+			citationSourceCacheMigrationSql,
 		]) {
 			for (const query of splitMigrationStatements(migration)) await env.DB.prepare(query).run();
 		}
@@ -137,6 +139,32 @@ describe("isolated Worker configuration and D1 migrations", () => {
 				.bind(validPublicId)
 				.run(),
 		).rejects.toThrow();
+	});
+
+	it("applies metadata-only source states and expiring fetch leases in workerd D1", async () => {
+		// Given: every committed migration applied to the test D1 binding.
+		const tables = await env.DB.prepare(
+			"SELECT name FROM sqlite_master WHERE type = 'table' AND name IN ('citation_source_states', 'citation_fetch_leases') ORDER BY name",
+		).all<{ readonly name: string }>();
+		const indexes = await env.DB.prepare(
+			"SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'citation_fetch_leases_expiry_idx'",
+		).all<{ readonly name: string }>();
+
+		// When: the source-cache schema is inspected and rejects malformed state storage.
+		await expect(
+			env.DB.prepare(
+				"INSERT INTO citation_source_states (normalized_citation, state_json, updated_at) VALUES (?1, ?2, ?3)",
+			)
+				.bind("", "not-json", "2026-08-09T00:00:00.000Z")
+				.run(),
+		).rejects.toThrow();
+
+		// Then: D1 contains only keyed metadata state plus the expiry index used for short leases.
+		expect(tables.results).toEqual([
+			{ name: "citation_fetch_leases" },
+			{ name: "citation_source_states" },
+		]);
+		expect(indexes.results).toEqual([{ name: "citation_fetch_leases_expiry_idx" }]);
 	});
 });
 

--- a/test/fixtures/citation-source-cache.ts
+++ b/test/fixtures/citation-source-cache.ts
@@ -1,0 +1,12 @@
+import migration from "../../migrations/0004_citation_source_cache.sql?raw";
+
+export async function resetCitationSourceCache(database: D1Database): Promise<void> {
+	await database.prepare("DROP TABLE IF EXISTS citation_fetch_leases").run();
+	await database.prepare("DROP TABLE IF EXISTS citation_source_states").run();
+	for (const statement of migration
+		.split(";")
+		.map((value) => value.trim())
+		.filter(Boolean)) {
+		await database.prepare(statement).run();
+	}
+}

--- a/test/fixtures/issue-6-worker.ts
+++ b/test/fixtures/issue-6-worker.ts
@@ -8,7 +8,12 @@ import { initialCourtListenerBudgetState } from "../../src/courtlistener/budget.
 import { createLocalAuthFixture } from "./api-key.js";
 import { resetCitationSourceCache } from "./citation-source-cache.js";
 
-export type CitationSourceMode = "absent" | "matched" | "server";
+export type CitationSourceMode =
+	| "absent"
+	| "matched"
+	| "mismatched_absent"
+	| "mismatched_matched"
+	| "server";
 
 export type Issue6WorkerFixture = {
 	readonly authorization: string;
@@ -48,8 +53,12 @@ export async function createIssue6WorkerFixture(publicId: string): Promise<Issue
 			switch (sourceMode) {
 				case "matched":
 					return Promise.resolve(citationResponse(200));
+				case "mismatched_matched":
+					return Promise.resolve(citationResponse(200, "1 U.S. 200"));
 				case "absent":
 					return Promise.resolve(citationResponse(404));
+				case "mismatched_absent":
+					return Promise.resolve(citationResponse(404, "1 U.S. 200"));
 				case "server":
 					return Promise.resolve(new Response(null, { status: 503 }));
 				default:
@@ -177,11 +186,11 @@ function usageResponse(): Response {
 	});
 }
 
-function citationResponse(status: 200 | 404): Response {
+function citationResponse(status: 200 | 404, normalizedCitation = NORMALIZED_CITATION): Response {
 	return Response.json([
 		{
 			status,
-			normalized_citations: [NORMALIZED_CITATION],
+			normalized_citations: [normalizedCitation],
 			clusters:
 				status === 200
 					? [{ id: 108713, absolute_url: "/opinion/108713/brown-v-board-of-education/" }]

--- a/test/fixtures/issue-6-worker.ts
+++ b/test/fixtures/issue-6-worker.ts
@@ -1,0 +1,195 @@
+import { env, runInDurableObject } from "cloudflare:test";
+import {
+	CLIENT_CAPABILITIES_META_KEY,
+	CLIENT_INFO_META_KEY,
+	PROTOCOL_VERSION_META_KEY,
+} from "@modelcontextprotocol/server";
+import { initialCourtListenerBudgetState } from "../../src/courtlistener/budget.js";
+import { createLocalAuthFixture } from "./api-key.js";
+import { resetCitationSourceCache } from "./citation-source-cache.js";
+
+export type CitationSourceMode = "absent" | "matched" | "server";
+
+export type Issue6WorkerFixture = {
+	readonly authorization: string;
+	readonly outbound: Request[];
+	readonly request: (citation?: string) => Request;
+	readonly resetCache: () => Promise<void>;
+	readonly seed: (state: unknown) => Promise<void>;
+	readonly setSourceMode: (mode: CitationSourceMode) => void;
+	readonly source: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+};
+
+const NORMALIZED_CITATION = "347 U.S. 483";
+const PROTOCOL_VERSION = "2026-07-28";
+
+export async function createIssue6WorkerFixture(publicId: string): Promise<Issue6WorkerFixture> {
+	const localAuth = await createLocalAuthFixture({ publicId });
+	await resetCitationSourceCache(env.DB);
+	await replaceApiKeyRecords(localAuth.record);
+	await resetCourtListenerBudget();
+
+	let sourceMode: CitationSourceMode = "matched";
+	const outbound: Request[] = [];
+	return {
+		authorization: `Bearer ${localAuth.token}`,
+		outbound,
+		request: (citation = NORMALIZED_CITATION) =>
+			citationRequest(`Bearer ${localAuth.token}`, citation),
+		resetCache: () => resetCitationSourceCache(env.DB),
+		seed: (state) => seedCitationSourceState(state),
+		setSourceMode: (mode) => {
+			sourceMode = mode;
+		},
+		source: (input, init) => {
+			const request = input instanceof Request ? input : new Request(input, init);
+			outbound.push(request);
+			if (request.method === "GET") return Promise.resolve(usageResponse());
+			switch (sourceMode) {
+				case "matched":
+					return Promise.resolve(citationResponse(200));
+				case "absent":
+					return Promise.resolve(citationResponse(404));
+				case "server":
+					return Promise.resolve(new Response(null, { status: 503 }));
+				default:
+					return assertNever(sourceMode);
+			}
+		},
+	};
+}
+
+export function positiveState(retrievedAt: Date) {
+	return {
+		kind: "positive",
+		positive: {
+			kind: "positive",
+			cluster: {
+				id: 108713,
+				canonicalUrl: "https://www.courtlistener.com/opinion/108713/brown-v-board-of-education/",
+			},
+			retrievedAt: retrievedAt.toISOString(),
+		},
+	};
+}
+
+export function pendingReversalState(firstNegativeAt: Date) {
+	return {
+		kind: "reversal_pending",
+		superseded: positiveState(new Date(firstNegativeAt.getTime() - 31 * 24 * 60 * 60 * 1_000))
+			.positive,
+		firstNegative: { kind: "negative", retrievedAt: firstNegativeAt.toISOString() },
+	};
+}
+
+async function replaceApiKeyRecords(record: {
+	readonly public_id: string;
+	readonly environment: string;
+	readonly hmac_sha256_hex: string;
+	readonly status: string;
+	readonly expires_at: string;
+	readonly revoked_at: string | null;
+	readonly minute_limit: number;
+	readonly day_limit: number;
+	readonly limits_version: number;
+}): Promise<void> {
+	await env.DB.prepare("DROP TABLE IF EXISTS api_key_records").run();
+	await env.DB.prepare(`CREATE TABLE api_key_records (
+		public_id TEXT PRIMARY KEY NOT NULL, environment TEXT NOT NULL, hmac_sha256_hex TEXT NOT NULL,
+		status TEXT NOT NULL, expires_at TEXT NOT NULL, revoked_at TEXT,
+		minute_limit INTEGER NOT NULL DEFAULT 60, day_limit INTEGER NOT NULL DEFAULT 1000,
+		limits_version INTEGER NOT NULL DEFAULT 1
+	)`).run();
+	await env.DB.prepare(
+		"INSERT INTO api_key_records (public_id, environment, hmac_sha256_hex, status, expires_at, revoked_at, minute_limit, day_limit, limits_version) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+	)
+		.bind(
+			record.public_id,
+			record.environment,
+			record.hmac_sha256_hex,
+			record.status,
+			record.expires_at,
+			record.revoked_at,
+			record.minute_limit,
+			record.day_limit,
+			record.limits_version,
+		)
+		.run();
+}
+
+async function resetCourtListenerBudget(): Promise<void> {
+	const coordinator = env.COURTLISTENER_COORDINATOR.getByName(env.COURTLISTENER_CREDENTIAL_ID);
+	await runInDurableObject(coordinator, (_instance, state) => {
+		state.storage.sql.exec(
+			"UPDATE courtlistener_budget_state SET state_json = ?1 WHERE singleton = 1",
+			JSON.stringify(initialCourtListenerBudgetState()),
+		);
+	});
+}
+
+function citationRequest(authorization: string, citation: string): Request {
+	return new Request("https://mcp.lexcerta.ai/", {
+		method: "POST",
+		headers: {
+			authorization,
+			"content-type": "application/json",
+			"mcp-method": "tools/call",
+			"mcp-name": "verify_citation",
+			"mcp-protocol-version": PROTOCOL_VERSION,
+		},
+		body: JSON.stringify({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "tools/call",
+			params: {
+				name: "verify_citation",
+				arguments: { citation },
+				_meta: {
+					[PROTOCOL_VERSION_META_KEY]: PROTOCOL_VERSION,
+					[CLIENT_INFO_META_KEY]: { name: "issue-6", version: "1.0.0" },
+					[CLIENT_CAPABILITIES_META_KEY]: {},
+				},
+			},
+		}),
+	});
+}
+
+async function seedCitationSourceState(state: unknown): Promise<void> {
+	await env.DB.prepare(
+		"INSERT INTO citation_source_states (normalized_citation, state_json, updated_at) VALUES (?1, ?2, ?3)",
+	)
+		.bind(NORMALIZED_CITATION, JSON.stringify(state), new Date().toISOString())
+		.run();
+}
+
+function usageResponse(): Response {
+	return Response.json({
+		current_usage: ["user", "citations", "api_usage"].map((scope) => ({
+			scope,
+			rate: "minute",
+			used: 0,
+			limit: 5,
+			remaining: 5,
+			window_seconds: 60,
+			reset_at: "2026-08-09T12:01:00.000Z",
+			blocked: false,
+		})),
+	});
+}
+
+function citationResponse(status: 200 | 404): Response {
+	return Response.json([
+		{
+			status,
+			normalized_citations: [NORMALIZED_CITATION],
+			clusters:
+				status === 200
+					? [{ id: 108713, absolute_url: "/opinion/108713/brown-v-board-of-education/" }]
+					: [],
+		},
+	]);
+}
+
+function assertNever(value: never): never {
+	throw new TypeError(`Unexpected fixture value: ${String(value)}`);
+}

--- a/test/issue-6-cache-poison.integration.test.ts
+++ b/test/issue-6-cache-poison.integration.test.ts
@@ -1,0 +1,40 @@
+import { SELF, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type Issue6WorkerFixture, createIssue6WorkerFixture } from "./fixtures/issue-6-worker.js";
+
+let fixture: Issue6WorkerFixture;
+
+beforeEach(async () => {
+	fixture = await createIssue6WorkerFixture(`cache-poison-${crypto.randomUUID()}`);
+	vi.stubGlobal("fetch", fixture.source);
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("issue 6 upstream response binding through the Worker", () => {
+	it.each([
+		["matched", "mismatched_matched"],
+		["absent", "mismatched_absent"],
+	] as const)("does not persist a mismatched conclusive %s response", async (_kind, sourceMode) => {
+		// Given: the trusted CourtListener origin returns a conclusive item for a different citation.
+		fixture.setSourceMode(sourceMode);
+
+		// When: the requested citation crosses the public Worker MCP boundary.
+		const response = await SELF.fetch(fixture.request());
+		const persisted = await env.DB.prepare(
+			"SELECT state_json FROM citation_source_states WHERE normalized_citation = ?1",
+		)
+			.bind("347 U.S. 483")
+			.first<unknown>();
+
+		// Then: the caller receives a sanitized indeterminate result and D1 has no source state.
+		expect(await response.json()).toMatchObject({
+			result: {
+				isError: true,
+				structuredContent: { outcome: "indeterminate", reason: "incomplete" },
+			},
+		});
+		expect(persisted).toBeNull();
+		expect(fixture.outbound.filter((request) => request.method === "POST")).toHaveLength(1);
+	});
+});

--- a/test/issue-6-negative-purge.integration.test.ts
+++ b/test/issue-6-negative-purge.integration.test.ts
@@ -1,0 +1,139 @@
+import { SELF, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createD1CitationObservationStore } from "../src/cache/d1-citation-observation-store.js";
+import type { PositiveCitationObservation } from "../src/verification/citation-source-cache.js";
+import {
+	createIssue6WorkerFixture,
+	positiveState,
+	type Issue6WorkerFixture,
+} from "./fixtures/issue-6-worker.js";
+
+const CITATION = "347 U.S. 483";
+const NOW = new Date("2026-08-09T12:00:00.000Z");
+let fixture: Issue6WorkerFixture;
+
+beforeEach(async () => {
+	fixture = await createIssue6WorkerFixture(`negative-purge-${crypto.randomUUID()}`);
+	vi.stubGlobal("fetch", fixture.source);
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("issue 6 expired negative purge", () => {
+	it("removes a standalone expired negative before a public failed revalidation", async () => {
+		await fixture.seed(staleNegativeState(null, new Date()));
+		fixture.setSourceMode("server");
+
+		const response = await SELF.fetch(fixture.request());
+		const row = await sourceStateRow();
+
+		expect(await response.json()).toMatchObject({
+			result: {
+				isError: true,
+				structuredContent: { outcome: "indeterminate", reason: "upstream_unavailable" },
+			},
+		});
+		expect(row).toBeNull();
+	});
+
+	it("retains superseded reversal history after a public failed revalidation", async () => {
+		const now = new Date();
+		const retrievedAt = new Date(now.getTime() - 31 * 24 * 60 * 60 * 1_000);
+		const superseded: PositiveCitationObservation = {
+			kind: "positive",
+			cluster: positiveState(retrievedAt).positive.cluster,
+			retrievedAt,
+		};
+		const stale = staleNegativeState(superseded, now);
+		await fixture.seed(stale);
+		fixture.setSourceMode("server");
+
+		const response = await SELF.fetch(fixture.request());
+		const row = await sourceStateRow();
+
+		expect(await response.json()).toMatchObject({
+			result: {
+				isError: true,
+				structuredContent: { outcome: "indeterminate", reason: "source_changed" },
+			},
+		});
+		expect(JSON.parse(requireStateJson(row))).toMatchObject({
+			kind: "reversal_pending",
+			superseded: { ...superseded, retrievedAt: superseded.retrievedAt.toISOString() },
+			firstNegative: { ...stale.negative, retrievedAt: stale.negative.retrievedAt.toISOString() },
+		});
+	});
+
+	it("does not purge a state changed after the lease owner reread it", async () => {
+		const stale = staleNegativeState(null);
+		await fixture.seed(stale);
+		const store = createD1CitationObservationStore(env.DB);
+		await store.acquireLease({ normalizedCitation: CITATION, ownerToken: "owner", now: NOW });
+		await env.DB.prepare(
+			"UPDATE citation_source_states SET state_json = ?1 WHERE normalized_citation = ?2",
+		)
+			.bind(JSON.stringify(positiveState(NOW)), CITATION)
+			.run();
+
+		const result = await store.purgeExpiredNegativeLease({
+			normalizedCitation: CITATION,
+			ownerToken: "owner",
+			now: NOW,
+			expected: stale,
+		});
+
+		expect(result).toEqual({ kind: "state_changed" });
+		await expect(store.read({ normalizedCitation: CITATION })).resolves.toEqual({
+			kind: "positive",
+			positive: { ...positiveState(NOW).positive, retrievedAt: NOW },
+		});
+	});
+
+	it("rejects an expired owner and a non-owner before purging durable state", async () => {
+		const stale = staleNegativeState(null);
+		await fixture.seed(stale);
+		const store = createD1CitationObservationStore(env.DB);
+		await store.acquireLease({ normalizedCitation: CITATION, ownerToken: "owner", now: NOW });
+
+		const otherOwner = await store.purgeExpiredNegativeLease({
+			normalizedCitation: CITATION,
+			ownerToken: "other-owner",
+			now: NOW,
+			expected: stale,
+		});
+		const expiredOwner = await store.purgeExpiredNegativeLease({
+			normalizedCitation: CITATION,
+			ownerToken: "owner",
+			now: new Date(NOW.getTime() + 10_000),
+			expected: stale,
+		});
+
+		expect(otherOwner).toEqual({ kind: "lease_unavailable" });
+		expect(expiredOwner).toEqual({ kind: "lease_unavailable" });
+		await expect(store.read({ normalizedCitation: CITATION })).resolves.toEqual(stale);
+	});
+});
+
+function staleNegativeState(superseded: PositiveCitationObservation | null, now = NOW) {
+	return {
+		kind: "negative" as const,
+		negative: {
+			kind: "negative" as const,
+			retrievedAt: new Date(now.getTime() - 25 * 60 * 60 * 1_000),
+		},
+		superseded,
+	};
+}
+
+async function sourceStateRow(): Promise<{ readonly state_json: string } | null> {
+	return env.DB.prepare(
+		"SELECT state_json FROM citation_source_states WHERE normalized_citation = ?1",
+	)
+		.bind(CITATION)
+		.first<{ readonly state_json: string }>();
+}
+
+function requireStateJson(row: { readonly state_json: string } | null): string {
+	if (row !== null) return row.state_json;
+	throw new TypeError("expected retained reversal history");
+}

--- a/test/issue-6-source-cache-race.integration.test.ts
+++ b/test/issue-6-source-cache-race.integration.test.ts
@@ -1,0 +1,121 @@
+import { SELF, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createD1CitationObservationStore } from "../src/cache/d1-citation-observation-store.js";
+import {
+	createIssue6WorkerFixture,
+	pendingReversalState,
+	type Issue6WorkerFixture,
+} from "./fixtures/issue-6-worker.js";
+
+let fixture: Issue6WorkerFixture;
+
+beforeEach(async () => {
+	fixture = await createIssue6WorkerFixture(`race-${crypto.randomUUID()}`);
+	vi.stubGlobal("fetch", fixture.source);
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("issue 6 cache races through the Worker", () => {
+	it("coalesces concurrent cold requests behind one CourtListener POST", async () => {
+		const [first, second] = await Promise.all([
+			SELF.fetch(fixture.request()),
+			SELF.fetch(fixture.request()),
+		]);
+
+		expect(await first.json()).toMatchObject({
+			result: { structuredContent: { outcome: "verified" } },
+		});
+		expect(await second.json()).toMatchObject({
+			result: { structuredContent: { outcome: "verified" } },
+		});
+		expect(citationPosts()).toHaveLength(1);
+	});
+
+	it("does not store an operational failure before a later successful retry", async () => {
+		fixture.setSourceMode("server");
+		await SELF.fetch(fixture.request());
+		fixture.setSourceMode("matched");
+
+		const retried = await SELF.fetch(fixture.request());
+
+		expect(await retried.json()).toMatchObject({
+			result: { structuredContent: { outcome: "verified" } },
+		});
+		expect(citationPosts()).toHaveLength(2);
+		expect(
+			await env.DB.prepare(
+				"SELECT state_json FROM citation_source_states WHERE normalized_citation = ?1",
+			)
+				.bind("347 U.S. 483")
+				.first<unknown>(),
+		).not.toBeNull();
+	});
+
+	it("charges a cache hit before denying the third authenticated request", async () => {
+		await env.DB.prepare("UPDATE api_key_records SET minute_limit = 2, day_limit = 2").run();
+		const first = await SELF.fetch(fixture.request());
+		const hit = await SELF.fetch(fixture.request());
+		const denied = await SELF.fetch(fixture.request());
+
+		expect(first.status).toBe(200);
+		expect(hit.status).toBe(200);
+		expect(denied.status).toBe(429);
+		expect(citationPosts()).toHaveLength(1);
+	});
+
+	it("keeps a 24-hour-minus-one reversal pending and accepts it at the exact boundary", async () => {
+		const fixed = new Date("2026-08-09T10:00:00.000Z");
+		vi.useFakeTimers();
+		vi.setSystemTime(fixed);
+		fixture.setSourceMode("absent");
+		try {
+			await fixture.seed(
+				pendingReversalState(new Date(fixed.getTime() - 24 * 60 * 60 * 1_000 + 1)),
+			);
+			const before = await SELF.fetch(fixture.request());
+			await fixture.resetCache();
+			await fixture.seed(pendingReversalState(new Date(fixed.getTime() - 24 * 60 * 60 * 1_000)));
+			const exact = await SELF.fetch(fixture.request());
+
+			expect(await before.json()).toMatchObject({
+				result: { structuredContent: { reason: "source_changed" } },
+			});
+			expect(await exact.json()).toMatchObject({
+				result: { structuredContent: { outcome: "not_found" } },
+			});
+		} finally {
+			vi.useRealTimers();
+		}
+	});
+
+	it("recovers an abandoned durable lease through the public Worker", async () => {
+		const store = createD1CitationObservationStore(env.DB);
+		await store.acquireLease({
+			normalizedCitation: "347 U.S. 483",
+			ownerToken: "old-owner",
+			now: new Date(Date.now() - 11_000),
+		});
+
+		const response = await SELF.fetch(fixture.request());
+		const late = await store.fillLease({
+			normalizedCitation: "347 U.S. 483",
+			ownerToken: "old-owner",
+			now: new Date(),
+			observation: {
+				kind: "positive",
+				cluster: { id: 1, canonicalUrl: "https://www.courtlistener.com/opinion/1/old/" },
+			},
+		});
+
+		expect(await response.json()).toMatchObject({
+			result: { structuredContent: { outcome: "verified" } },
+		});
+		expect(citationPosts()).toHaveLength(1);
+		expect(late).toEqual({ kind: "lease_unavailable" });
+	});
+});
+
+function citationPosts(): Request[] {
+	return fixture.outbound.filter((request) => request.method === "POST");
+}

--- a/test/issue-6-source-cache.integration.test.ts
+++ b/test/issue-6-source-cache.integration.test.ts
@@ -1,0 +1,179 @@
+import { SELF, env } from "cloudflare:test";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	createIssue6WorkerFixture,
+	pendingReversalState,
+	positiveState,
+	type Issue6WorkerFixture,
+} from "./fixtures/issue-6-worker.js";
+
+let fixture: Issue6WorkerFixture;
+const COURTLISTENER_TEST_CREDENTIAL = "fixture-courtlistener-token";
+
+beforeEach(async () => {
+	fixture = await createIssue6WorkerFixture(`source-cache-${crypto.randomUUID()}`);
+	vi.stubGlobal("fetch", fixture.source);
+});
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("issue 6 source cache through the Worker", () => {
+	it("avoids CourtListener for a durable fresh positive cache hit", async () => {
+		await SELF.fetch(fixture.request());
+
+		const response = await SELF.fetch(fixture.request());
+
+		expect(await response.json()).toMatchObject({
+			result: { structuredContent: { outcome: "verified", evidence: { freshness: "fresh" } } },
+		});
+		expect(outboundMethods()).toEqual(["GET", "POST"]);
+	});
+
+	it("returns retained stale positive evidence when revalidation fails", async () => {
+		const retrievedAt = new Date(Date.now() - 31 * 24 * 60 * 60 * 1_000);
+		await fixture.seed(positiveState(retrievedAt));
+		fixture.setSourceMode("server");
+
+		const response = await SELF.fetch(fixture.request());
+
+		expect(await response.json()).toMatchObject({
+			result: {
+				structuredContent: {
+					outcome: "verified",
+					evidence: { freshness: "stale", retrievedAt: retrievedAt.toISOString() },
+				},
+			},
+		});
+	});
+
+	it("reuses fresh negative evidence without a second CourtListener POST", async () => {
+		fixture.setSourceMode("absent");
+		const first = await SELF.fetch(fixture.request());
+		const second = await SELF.fetch(fixture.request());
+
+		expect(await first.json()).toMatchObject({
+			result: { structuredContent: { outcome: "not_found" } },
+		});
+		expect(await second.json()).toMatchObject({
+			result: { structuredContent: { outcome: "not_found" } },
+		});
+		expect(outboundMethods()).toEqual(["GET", "POST"]);
+	});
+
+	it("never returns not_found from an expired negative", async () => {
+		await fixture.seed({
+			kind: "negative",
+			negative: {
+				kind: "negative",
+				retrievedAt: new Date(Date.now() - 25 * 60 * 60 * 1_000).toISOString(),
+			},
+			superseded: null,
+		});
+		fixture.setSourceMode("server");
+
+		const response = await SELF.fetch(fixture.request());
+
+		expect(await response.json()).toMatchObject({
+			result: {
+				isError: true,
+				structuredContent: { outcome: "indeterminate", reason: "upstream_unavailable" },
+			},
+		});
+		expect(outboundMethods()).toEqual(["GET", "POST"]);
+	});
+
+	it("returns source_changed when fresh absence contradicts retained positive evidence", async () => {
+		await fixture.seed(positiveState(new Date(Date.now() - 31 * 24 * 60 * 60 * 1_000)));
+		fixture.setSourceMode("absent");
+
+		const response = await SELF.fetch(fixture.request());
+
+		expect(await response.json()).toMatchObject({
+			result: {
+				isError: true,
+				structuredContent: { outcome: "indeterminate", reason: "source_changed" },
+			},
+		});
+	});
+
+	it("accepts a confirmed negative reversal at the 24-hour boundary", async () => {
+		await fixture.seed(pendingReversalState(new Date(Date.now() - 24 * 60 * 60 * 1_000)));
+		fixture.setSourceMode("absent");
+
+		const response = await SELF.fetch(fixture.request());
+
+		expect(await response.json()).toMatchObject({
+			result: { isError: false, structuredContent: { outcome: "not_found" } },
+		});
+	});
+
+	it("restores normal verified output when a pending reversal is renewed positive", async () => {
+		await fixture.seed(pendingReversalState(new Date()));
+
+		const response = await SELF.fetch(fixture.request());
+
+		expect(await response.json()).toMatchObject({
+			result: {
+				isError: false,
+				structuredContent: { outcome: "verified", evidence: { freshness: "fresh" } },
+			},
+		});
+	});
+
+	it("fails closed when the authoritative source-cache D1 table is unavailable", async () => {
+		await env.DB.prepare("DROP TABLE citation_source_states").run();
+
+		const response = await SELF.fetch(fixture.request());
+
+		expect(await response.json()).toMatchObject({
+			result: {
+				isError: true,
+				structuredContent: { outcome: "indeterminate", reason: "upstream_unavailable" },
+			},
+		});
+		expect(fixture.outbound).toHaveLength(0);
+	});
+
+	it("never exposes legal content or credentials in runtime logs, responses, cache, or leases", async () => {
+		const sentinelSuffix = "issue-6-redaction-sentinel";
+		const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+		const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+		try {
+			const response = await SELF.fetch(fixture.request(`347 U.S. 483, 490 (${sentinelSuffix})`));
+			const responseBody = await response.text();
+			const persisted = await persistedSourceCacheAndLeases();
+			const logged = JSON.stringify([...error.mock.calls, ...warn.mock.calls]);
+
+			expect(JSON.parse(responseBody)).toMatchObject({
+				result: { structuredContent: { outcome: "verified" } },
+			});
+			for (const protectedValue of [
+				sentinelSuffix,
+				fixture.authorization,
+				fixture.authorization.slice("Bearer ".length),
+				COURTLISTENER_TEST_CREDENTIAL,
+			]) {
+				expect(responseBody.includes(protectedValue)).toBe(false);
+				expect(persisted.includes(protectedValue)).toBe(false);
+				expect(logged.includes(protectedValue)).toBe(false);
+			}
+		} finally {
+			error.mockRestore();
+			warn.mockRestore();
+		}
+	});
+});
+
+function outboundMethods(): string[] {
+	return fixture.outbound.map((request) => request.method);
+}
+
+async function persistedSourceCacheAndLeases(): Promise<string> {
+	const [states, leases] = await Promise.all([
+		env.DB.prepare("SELECT state_json FROM citation_source_states").all(),
+		env.DB.prepare(
+			"SELECT normalized_citation, owner_token, expires_at FROM citation_fetch_leases",
+		).all(),
+	]);
+	return JSON.stringify({ states, leases });
+}

--- a/test/worker-citation-reservation.integration.test.ts
+++ b/test/worker-citation-reservation.integration.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 import { initialCourtListenerBudgetState } from "../src/courtlistener/budget.js";
 import { createLocalAuthFixture } from "./fixtures/api-key.js";
+import { resetCitationSourceCache } from "./fixtures/citation-source-cache.js";
 
 type Deferred<Value> = {
 	readonly promise: Promise<Value>;
@@ -26,6 +27,7 @@ const outbound: Request[] = [];
 
 beforeEach(async () => {
 	const fixture = await createLocalAuthFixture({ publicId: `reservation-${crypto.randomUUID()}` });
+	await resetCitationSourceCache(env.DB);
 	await env.DB.prepare("DROP TABLE IF EXISTS api_key_records").run();
 	await env.DB.prepare(`CREATE TABLE api_key_records (
 		public_id TEXT PRIMARY KEY NOT NULL, environment TEXT NOT NULL, hmac_sha256_hex TEXT NOT NULL,

--- a/test/worker-citation.integration.test.ts
+++ b/test/worker-citation.integration.test.ts
@@ -7,6 +7,7 @@ import {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { initialCourtListenerBudgetState } from "../src/courtlistener/budget.js";
 import { createLocalAuthFixture } from "./fixtures/api-key.js";
+import { resetCitationSourceCache } from "./fixtures/citation-source-cache.js";
 
 let authorization = "";
 const outbound: Request[] = [];
@@ -17,6 +18,7 @@ let citationFixture: CitationFixture = "matched";
 
 beforeEach(async () => {
 	const fixture = await createLocalAuthFixture({ publicId: `citation-${crypto.randomUUID()}` });
+	await resetCitationSourceCache(env.DB);
 	await env.DB.prepare("DROP TABLE IF EXISTS api_key_records").run();
 	await env.DB.prepare(`CREATE TABLE api_key_records (
 			public_id TEXT PRIMARY KEY NOT NULL,
@@ -231,6 +233,11 @@ describe("Worker citation verification", () => {
 						structuredContent: { evidence: { searchComplete: true, source: "courtlistener" } },
 					},
 				});
+				const cached = await SELF.fetch(citationRequest());
+				expect(await cached.json()).toMatchObject({
+					result: { isError: false, structuredContent: { outcome: "not_found" } },
+				});
+				expect(outbound.map((request) => request.method)).toEqual(["GET", "POST"]);
 			}
 			if (reason === "rate_limited") {
 				expect(body).toMatchObject({


### PR DESCRIPTION
Closes #6.

## What changed

- add a durable D1 citation observation cache with 30-day positive and 24-hour negative freshness
- coalesce concurrent misses with expiring normalized-citation fetch leases
- preserve stale positive provenance and require two separated negative observations before accepting a reversal
- purge expired negative evidence under an active owner/state CAS before revalidation
- bind conclusive CourtListener responses to the exact requested normalized citation before caching
- wait for active cache-fill owners with bounded expiry-aware backoff
- expose fresh/stale/source-changed results through `verify_citation`

## Why

Repeated verification should reuse trustworthy CourtListener evidence without treating stale or contradictory observations as permanent truth, issuing avoidable upstream requests, or allowing mismatched upstream records to poison the cache.

## Verification

- `npm run check` (286 Worker tests, 37 admin tests)
- public/admin Wrangler dry-runs for production/test/local configurations
- production dependency audit: 0 vulnerabilities
- five independent exact-SHA review lanes PASS at `a65921fba43ece90aaeae65d927e1b8a8a9e4183`
- adversarial cache/race matrix: 240/240 repeated cases
